### PR TITLE
Fix potential overflows in Navien gas data handling

### DIFF
--- a/Navien.h
+++ b/Navien.h
@@ -306,8 +306,8 @@ enum CommandActionHotButton {
       float panel_version;
       float accumulated_gas_usage;    // m^3 (ccf = m^3 / 2.832, Therms = m^3 / 2.832 * 1.02845 )
       uint16_t current_gas_usage;     // kcal (btu == kcal * 3.965667)
-      uint16_t total_operating_time;  // seconds
-      int accumulated_domestic_usage_cnt; 
+      uint32_t total_operating_time;  // seconds - expanded to handle large values
+      uint32_t accumulated_domestic_usage_cnt;  // Counter for domestic usage, multiplied by 10
     } gas;
 
     struct {


### PR DESCRIPTION
Improves handling of gas-related counters in the Navien interface by using appropriate data types to prevent overflow:

- Changed total_operating_time from uint16_t to uint32_t to safely handle seconds calculation
- Changed accumulated_domestic_usage_cnt from int32_t to uint32_t as it's a positive counter
- Simplified overflow protection code since uint32_t can handle the full range
- Added explicit float literal (0.1f) for accumulated gas usage calculation

These changes prevent potential overflows when calculating:
- Operating time (60 * raw_time)
- Domestic usage count (10 * raw_usage)

The code is now more maintainable and safer, using consistent uint32_t types for large counters.



Created with [**Solver**](https://solverai.com)