### PR TITLE
Remove timezone dependence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+TimeUtils_test

--- a/BucketStore.cpp
+++ b/BucketStore.cpp
@@ -64,7 +64,7 @@ bool BucketStore::begin() {
 
     // File absent or corrupt — start fresh.
     time_t now = time(nullptr);
-    struct tm *tm_info = localtime(&now);
+    struct tm *tm_info = gmtime(&now);
     uint16_t year = (tm_info && tm_info->tm_year > 100)
                     ? (uint16_t)(tm_info->tm_year + 1900)
                     : 2025;

--- a/BucketStore.h
+++ b/BucketStore.h
@@ -30,7 +30,7 @@ SOFTWARE.
 
 // Magic number: "NAVI" in little-endian ASCII bytes
 #define BUCKET_MAGIC          0x4E415649u
-#define BUCKET_SCHEMA_VERSION 1
+#define BUCKET_SCHEMA_VERSION 2
 
 // 7 days x 288 five-minute buckets (1440 min / 5)
 #define BUCKET_DAYS    7

--- a/FakeGatoScheduler.cpp
+++ b/FakeGatoScheduler.cpp
@@ -27,6 +27,7 @@
 #include "Navien.h"
 #include "TimeUtils.h"
 #include <ArduinoJson.h>
+#include <climits>
 
 extern Navien navienSerial;
 extern NavienLearner *learner;
@@ -627,9 +628,27 @@ void FakeGatoScheduler::loop() {
     // Build a local-time copy for Eve readback; prog_send_data stays UTC internally.
     PROG_DATA_FULL_DATA sendData = prog_send_data;
     if (_scheduleIsUtc) {
+      // Determine UTC→local offset for readback.  Prefer the Eve-confirmed offset;
+      // fall back to the system TZ (loaded from NVS in begin()) so the first Eve
+      // connection after a reboot doesn't send UTC times that Eve misinterprets as
+      // local (which would cause a double-conversion on the next write).
+      int effectiveOffsetMin = 0;
+      if (_utcOffsetKnown) {
+        effectiveOffsetMin = _lastKnownUtcOffsetMin;
+      } else if (getenv("TZ") && time(nullptr) > 1700000000L) {
+        time_t now2 = time(nullptr);
+        struct tm local_tm, utc_tm;
+        localtime_r(&now2, &local_tm);
+        gmtime_r(&now2, &utc_tm);
+        effectiveOffsetMin = (utc_tm.tm_hour * 60 + utc_tm.tm_min)
+                           - (local_tm.tm_hour * 60 + local_tm.tm_min);
+        if (effectiveOffsetMin >  720) effectiveOffsetMin -= 1440;
+        if (effectiveOffsetMin < -720) effectiveOffsetMin += 1440;
+      }
+
       // Convert stored UTC schedule → local time for Eve display.
       convertSlotsOffset(prog_send_data.weekSchedule, sendData.weekSchedule,
-                         -_lastKnownUtcOffsetMin);
+                         -effectiveOffsetMin);
       // currentSchedule must also reflect local-time today for Eve.
       time_t now2 = time(nullptr);
       struct tm *ts = localtime(&now2);  // intentionally local-time — Eve display
@@ -683,13 +702,19 @@ void FakeGatoScheduler::convertSlotsOffset(const PROG_CMD_WEEK_SCHEDULE &in,
         continue;
       }
 
-      uint8_t off_start = (uint8_t)(shifted_start / 10);
-      uint8_t off_end   = (uint8_t)(shifted_end   / 10);
+      // Round to nearest 10-min boundary (Eve wire format resolution).
+      // Without rounding, a 1-min jitter in _lastKnownUtcOffsetMin truncates
+      // to the wrong 10-min slot (e.g. 599/10=59 → 9:50 instead of 10:00).
+      uint8_t off_start = (uint8_t)((shifted_start + 5) / 10);
+      uint8_t off_end   = (uint8_t)((shifted_end   + 5) / 10);
+      // Clamp to valid Eve range (max 23:50 = offset 143).
+      if (off_start > 143) off_start = 143;
+      if (off_end   > 143) off_end   = 143;
 
-      // Write into first free slot of the target day.
+      // Write into first free slot of the target day (max 3 — Eve UI limit).
       CMD_DAY_SCHEDULE *targetDay = &out.day[target_day];
       bool written = false;
-      for (int s = 0; s < 4; s++) {
+      for (int s = 0; s < 3; s++) {
         if (targetDay->slot[s].offset_start == 0xFF) {
           targetDay->slot[s].offset_start = off_start;
           targetDay->slot[s].offset_end   = off_end;
@@ -698,15 +723,46 @@ void FakeGatoScheduler::convertSlotsOffset(const PROG_CMD_WEEK_SCHEDULE &in,
         }
       }
       if (!written) {
-        WEBLOG("SCHEDULER convertSlotsOffset: target Eve day %d full, slot dropped (start offset=%d)", target_day, off_start);
+        WEBLOG("SCHEDULER convertSlotsOffset: local day %d full (3-slot Eve limit), slot dropped (UTC start offset=%d) — fires correctly on device", target_day, off_start);
       }
     }
+  }
+}
+
+int FakeGatoScheduler::getEffectiveOffsetMin() const {
+  if (_utcOffsetKnown) return _lastKnownUtcOffsetMin;
+  if (getenv("TZ") && time(nullptr) > 1700000000L) {
+    time_t now = time(nullptr);
+    struct tm local_tm, utc_tm;
+    localtime_r(&now, &local_tm);
+    gmtime_r(&now, &utc_tm);
+    int off = (utc_tm.tm_hour * 60 + utc_tm.tm_min)
+            - (local_tm.tm_hour * 60 + local_tm.tm_min);
+    if (off >  720) off -= 1440;
+    if (off < -720) off += 1440;
+    return off;
+  }
+  return INT_MIN;
+}
+
+void FakeGatoScheduler::sanitizeScheduleToLocalLimit(int offsetMin) {
+  // Round-trip UTC→local→UTC. convertSlotsOffset enforces 3 slots per output
+  // day in both directions, so any slot that would be invisible in Eve (because
+  // its local day is already full) is dropped from storage here, preventing it
+  // from firing silently.
+  PROG_CMD_WEEK_SCHEDULE localView, sanitized;
+  convertSlotsOffset(prog_send_data.weekSchedule, localView,  -offsetMin);
+  convertSlotsOffset(localView,                   sanitized,  +offsetMin);
+  if (memcmp(&prog_send_data.weekSchedule, &sanitized, sizeof(sanitized)) != 0) {
+    WEBLOG("SCHEDULER: slots trimmed from UTC schedule — would exceed 3 per local day and be invisible in Eve");
+    memcpy(&prog_send_data.weekSchedule, &sanitized, sizeof(sanitized));
   }
 }
 
 void FakeGatoScheduler::convertEveSlotsToUTC(int utcOffsetMin) {
   PROG_CMD_WEEK_SCHEDULE orig = prog_send_data.weekSchedule;
   convertSlotsOffset(orig, prog_send_data.weekSchedule, utcOffsetMin);
+  sanitizeScheduleToLocalLimit(utcOffsetMin);
 }
 
 void FakeGatoScheduler::printData(uint8_t *data, int len) {

--- a/FakeGatoScheduler.cpp
+++ b/FakeGatoScheduler.cpp
@@ -550,6 +550,11 @@ int FakeGatoScheduler::begin() {
     // prog_send_data is the authoritative source for FakeGatoScheduler.
     updateSchedulerWeekSchedule();
     updateCurrentScheduleIfNeeded(true);
+
+    // TODO(Phase 3): check schedVersion in SAVED_DATA here; if slots have been
+    // migrated to UTC, call setScheduleUtcMode(true) to enable the
+    // learner→scheduler handoff path.
+
     return true;
   }
 
@@ -562,7 +567,10 @@ void FakeGatoScheduler::loop() {
   // Apply any new schedule produced by NavienLearner on Core 0.
   // checkNewSchedule() is non-blocking; it returns false immediately if no
   // new schedule is ready.  setWeekScheduleFromJSON() must only run on Core 1.
-  if (learner && !learner->isDisabled()) {
+  // Only apply learner-generated (UTC) schedules once the scheduler firing
+  // path is also UTC-based (Phase 3).  Before that, applying UTC slots to a
+  // localtime-based scheduler would cause firings at the wrong wall-clock time.
+  if (_scheduleIsUtc && learner && !learner->isDisabled()) {
     String newScheduleJson;
     if (learner->checkNewSchedule(newScheduleJson)) {
       setWeekScheduleFromJSON(newScheduleJson);

--- a/FakeGatoScheduler.cpp
+++ b/FakeGatoScheduler.cpp
@@ -25,35 +25,11 @@
 #include "FakeGatoScheduler.h"
 #include "NavienLearner.h"
 #include "Navien.h"
+#include "TimeUtils.h"
 #include <ArduinoJson.h>
 
 extern Navien navienSerial;
 extern NavienLearner *learner;
-
-// Unfortunately, ESP32 doesn't have the timegm() function, so implement one here
-time_t timegm(struct tm *tm) {
-    // Save current TZ
-    char *oldTZ = getenv("TZ");
-    char *oldTZCopy = oldTZ ? strdup(oldTZ) : nullptr;  // Make a copy
-    
-    // Temporarily set TZ to UTC
-    setenv("TZ", "UTC0", 1);
-    tzset();
-
-    // Convert to time_t (interpreted as UTC)
-    time_t utcTime = mktime(tm);
-
-    // Restore previous TZ
-    if (oldTZCopy) {
-        setenv("TZ", oldTZCopy, 1);
-        free(oldTZCopy);
-    } else {
-        unsetenv("TZ");  // Reset if there was no previous TZ
-    }
-    tzset();
-
-    return utcTime;
-}
 
 FakeGatoScheduler::FakeGatoScheduler()
 : SchedulerBase() {
@@ -175,6 +151,7 @@ void FakeGatoScheduler::stateChange(State newState){
 }
 
 void FakeGatoScheduler::addMilliseconds(PROG_CMD_CURRENT_TIME *timeStruct, uint32_t milliseconds) {
+    // Eve wire time — intentionally local-time (sent back to Eve for display only).
     // Convert milliseconds to seconds and remaining milliseconds
   uint32_t secondsToAdd = milliseconds / 1000;
   milliseconds %= 1000;  // Remaining milliseconds (not stored in struct)
@@ -202,6 +179,7 @@ void FakeGatoScheduler::addMilliseconds(PROG_CMD_CURRENT_TIME *timeStruct, uint3
 }
 
 void FakeGatoScheduler::guessTimeZone(PROG_CMD_CURRENT_TIME *eveLocalTime) {
+  // TZ is now display-only; wrong TZ corrupts Eve display but not schedule firing.
 
     struct tm eveTimeInfo = {0};  // Initialize to zero
 
@@ -212,7 +190,7 @@ void FakeGatoScheduler::guessTimeZone(PROG_CMD_CURRENT_TIME *eveLocalTime) {
     eveTimeInfo.tm_min  = eveLocalTime->minutes;
     eveTimeInfo.tm_sec  = 0;  // Assuming seconds are zero
 
-    time_t localTime =  timegm(&eveTimeInfo);  // Convert to time_t (Unix timestamp) *IGNORING TIMEZONE*
+    time_t localTime = proper_timegm(&eveTimeInfo);  // treat Eve local as UTC to get pseudo-epoch
     time_t currentTime = time(nullptr);  // Get the current system time
     struct tm *deviceLocalTime = localtime(&currentTime); // Convert to local time struct
 
@@ -226,7 +204,7 @@ void FakeGatoScheduler::guessTimeZone(PROG_CMD_CURRENT_TIME *eveLocalTime) {
 
     double timeDiffSeconds = difftime(currentTime, localTime);
     int timeDiffHours = std::round(timeDiffSeconds / 3600.0);
-    
+
     char tzString[10];
     snprintf(tzString, sizeof(tzString), "UTC%+d", timeDiffHours);
 
@@ -417,7 +395,38 @@ void FakeGatoScheduler::parseProgramData(uint8_t *data, int len) {
           printDaySchedule(&weekSchedule->day[day]);
         }
         Serial.println("");
-        memcpy(&prog_send_data.weekSchedule, weekSchedule, sizeof(PROG_CMD_WEEK_SCHEDULE));
+        // Compute best available UTC offset for conversion.
+        // Use _lastKnownUtcOffsetMin if already set this session; otherwise
+        // recompute inline from the saved currentTime so a lone WEEK_SCHEDULE
+        // packet (or one arriving before CURRENT_TIME) still converts correctly.
+        {
+          int offsetToUse = _lastKnownUtcOffsetMin;
+          if (prog_send_data.currentTime.year != 0 && time(nullptr) > 1700000000L) {
+            struct tm eveUTC = {0};
+            eveUTC.tm_year = prog_send_data.currentTime.year + 100;
+            eveUTC.tm_mon  = prog_send_data.currentTime.month - 1;
+            eveUTC.tm_mday = prog_send_data.currentTime.day;
+            eveUTC.tm_hour = prog_send_data.currentTime.hours;
+            eveUTC.tm_min  = prog_send_data.currentTime.minutes;
+            time_t evePseudo = proper_timegm(&eveUTC);
+            time_t sysUTC = time(nullptr);
+            int computed = (int)(difftime(sysUTC, evePseudo) / 60.0 + 0.5);
+            if (computed >= -720 && computed <= 720) {
+              offsetToUse = computed;
+              _utcOffsetKnown = true;
+            }
+          }
+          if (!_utcOffsetKnown) {
+            // Offset unknown: discard the received schedule rather than storing
+            // unconverted local slots into a UTC-based scheduler.  Eve will
+            // re-send after CURRENT_TIME establishes the offset.
+            WEBLOG("SCHEDULER UTC offset unknown; discarding WEEK_SCHEDULE (will re-apply once CURRENT_TIME received)");
+            byte_offset += sizeof(PROG_CMD_WEEK_SCHEDULE);
+            break;
+          }
+          memcpy(&prog_send_data.weekSchedule, weekSchedule, sizeof(PROG_CMD_WEEK_SCHEDULE));
+          convertEveSlotsToUTC(offsetToUse);
+        }
         updateSchedulerWeekSchedule();
         updateCurrentScheduleIfNeeded(true);
         initializeCurrentState(); // Recalculate current state after schedule change
@@ -436,6 +445,25 @@ void FakeGatoScheduler::parseProgramData(uint8_t *data, int len) {
         memcpy(&prog_send_data.currentTime, currentTime, sizeof(PROG_CMD_CURRENT_TIME));
         clockOffset = millis();
         guessTimeZone(currentTime);
+        // Compute UTC offset: treat Eve local time as UTC pseudo-epoch, diff against real UTC.
+        // Sign: UTC = Eve_local + _lastKnownUtcOffsetMin (PST/UTC-8 → offset = +480).
+        {
+          struct tm eveUTC = {0};
+          eveUTC.tm_year = currentTime->year + 100;
+          eveUTC.tm_mon  = currentTime->month - 1;
+          eveUTC.tm_mday = currentTime->day;
+          eveUTC.tm_hour = currentTime->hours;
+          eveUTC.tm_min  = currentTime->minutes;
+          time_t evePseudo = proper_timegm(&eveUTC);
+          time_t sysUTC    = time(nullptr);
+          int newOffset = (int)(difftime(sysUTC, evePseudo) / 60.0 + 0.5);
+          if (newOffset < -720 || newOffset > 720) {
+            WEBLOG("SCHEDULER UTC offset %d min out of range, ignoring", newOffset);
+          } else {
+            _lastKnownUtcOffsetMin = newOffset;
+            _utcOffsetKnown = true;
+          }
+        }
         byte_offset += sizeof(PROG_CMD_CURRENT_TIME);
         break;
       }
@@ -470,6 +498,7 @@ void FakeGatoScheduler::parseProgramData(uint8_t *data, int len) {
 }
 
 void FakeGatoScheduler::updateCurrentScheduleIfNeeded(bool force) {
+  // Intentionally localtime — selects which local day to show Eve.
   time_t now = time(nullptr);
   struct tm *tm_struct = localtime(&now);
   int eveDayOfWeek = (tm_struct->tm_wday + 6) % 7; // Convert to Monday - Sunday
@@ -545,15 +574,28 @@ bool FakeGatoScheduler::setWeekScheduleFromJSON(const String &json) {
 
 int FakeGatoScheduler::begin() {
   if (SchedulerBase::begin()) {
+    // Check schedVersion in SAVED_DATA.  Any firmware prior to Phase 3 stored
+    // local-time slots; version 1 means slots are already UTC.  If missing or
+    // wrong, clear the schedule so the user re-pushes from Eve (which will
+    // then convert via convertEveSlotsToUTC on the next write).
+    uint8_t schedVersion = 0;
+    nvs_get_u8(savedData, "schedVersion", &schedVersion);
+    if (schedVersion != 1) {
+      WEBLOG("SCHEDULER schedVersion %d: clearing local-time slots; re-push schedule from Eve", (int)schedVersion);
+      memset(&prog_send_data.weekSchedule.day, 0xFF, sizeof(prog_send_data.weekSchedule.day));
+      memset(&prog_send_data.currentSchedule.current, 0xFF, sizeof(prog_send_data.currentSchedule.current));
+      nvs_set_u8(savedData, "schedVersion", 1);
+      nvs_set_blob(savedData, "PROG_SEND_DATA", &prog_send_data, sizeof(prog_send_data));
+      nvs_commit(savedData);
+    }
+
     // Re-apply Eve schedule data on top of whatever SchedulerBase::begin()
-    // loaded (NVS "SCHEDULER" stale data or initDefault). Eve data in
-    // prog_send_data is the authoritative source for FakeGatoScheduler.
+    // loaded. Eve data in prog_send_data is the authoritative source.
     updateSchedulerWeekSchedule();
     updateCurrentScheduleIfNeeded(true);
 
-    // TODO(Phase 3): check schedVersion in SAVED_DATA here; if slots have been
-    // migrated to UTC, call setScheduleUtcMode(true) to enable the
-    // learner→scheduler handoff path.
+    // Slots are now UTC (either confirmed by schedVersion==1 or cleared for re-push).
+    setScheduleUtcMode(true);
 
     return true;
   }
@@ -581,12 +623,91 @@ void FakeGatoScheduler::loop() {
     updateCurrentScheduleIfNeeded(false);
     addMilliseconds(&prog_send_data.currentTime, millis() - clockOffset);
     clockOffset = millis();
+
+    // Build a local-time copy for Eve readback; prog_send_data stays UTC internally.
+    PROG_DATA_FULL_DATA sendData = prog_send_data;
+    if (_scheduleIsUtc) {
+      // Convert stored UTC schedule → local time for Eve display.
+      convertSlotsOffset(prog_send_data.weekSchedule, sendData.weekSchedule,
+                         -_lastKnownUtcOffsetMin);
+      // currentSchedule must also reflect local-time today for Eve.
+      time_t now2 = time(nullptr);
+      struct tm *ts = localtime(&now2);  // intentionally local-time — Eve display
+      int eveDow = (ts->tm_wday + 6) % 7;
+      memcpy(&sendData.currentSchedule.current,
+             &sendData.weekSchedule.day[eveDow], sizeof(CMD_DAY_SCHEDULE));
+    }
+
     // Don't announce when there is new program data, Eve app will fetch it when it wants it.
-    programData->setData((const uint8_t *)&prog_send_data, sizeof(PROG_DATA_FULL_DATA), refreshProgramData);
+    programData->setData((const uint8_t *)&sendData, sizeof(PROG_DATA_FULL_DATA), refreshProgramData);
     refreshProgramData = false;
   }
 }
 
+
+void FakeGatoScheduler::convertSlotsOffset(const PROG_CMD_WEEK_SCHEDULE &in,
+                                            PROG_CMD_WEEK_SCHEDULE &out,
+                                            int offsetMin) {
+  // General slot offset converter. offsetMin > 0 shifts forward (local→UTC for PST),
+  // offsetMin < 0 shifts backward (UTC→local for readback).
+  // Eve day 0=Monday..6=Sunday; offset units are value*10 minutes past midnight.
+  memset(&out.day, 0xFF, sizeof(out.day));
+
+  for (int d = 0; d < 7; d++) {
+    const CMD_DAY_SCHEDULE *daySched = &in.day[d];
+    for (int i = 0; i < 4 && daySched->slot[i].offset_start != 0xFF; i++) {
+      int t_start = daySched->slot[i].offset_start * 10; // minutes since midnight
+      int t_end   = daySched->slot[i].offset_end   * 10;
+      int shifted_start = t_start + offsetMin;
+      int shifted_end   = t_end   + offsetMin;
+
+      // Day rollover: adjust target day and normalise both times together.
+      int target_day = d;
+      if (shifted_start < 0) {
+        target_day = (d + 6) % 7; // previous day
+        shifted_start += 1440;
+        shifted_end   += 1440;
+      } else if (shifted_start >= 1440) {
+        target_day = (d + 1) % 7; // next day
+        shifted_start -= 1440;
+        shifted_end   -= 1440;
+      }
+
+      // Clamp end to 23:50 (offset 143); warn if slot straddles midnight.
+      if (shifted_end > 1430) {
+        WEBLOG("SCHEDULER convertSlotsOffset: Eve day %d slot %d straddles midnight (offset=%d), truncating end to 23:50", d, i, offsetMin);
+        shifted_end = 1430;
+      }
+      if (shifted_end <= shifted_start) {
+        WEBLOG("SCHEDULER convertSlotsOffset: Eve day %d slot %d zero/negative duration after conversion, skipping", d, i);
+        continue;
+      }
+
+      uint8_t off_start = (uint8_t)(shifted_start / 10);
+      uint8_t off_end   = (uint8_t)(shifted_end   / 10);
+
+      // Write into first free slot of the target day.
+      CMD_DAY_SCHEDULE *targetDay = &out.day[target_day];
+      bool written = false;
+      for (int s = 0; s < 4; s++) {
+        if (targetDay->slot[s].offset_start == 0xFF) {
+          targetDay->slot[s].offset_start = off_start;
+          targetDay->slot[s].offset_end   = off_end;
+          written = true;
+          break;
+        }
+      }
+      if (!written) {
+        WEBLOG("SCHEDULER convertSlotsOffset: target Eve day %d full, slot dropped (start offset=%d)", target_day, off_start);
+      }
+    }
+  }
+}
+
+void FakeGatoScheduler::convertEveSlotsToUTC(int utcOffsetMin) {
+  PROG_CMD_WEEK_SCHEDULE orig = prog_send_data.weekSchedule;
+  convertSlotsOffset(orig, prog_send_data.weekSchedule, utcOffsetMin);
+}
 
 void FakeGatoScheduler::printData(uint8_t *data, int len) {
   Serial.printf("Data %d ", len);

--- a/FakeGatoScheduler.h
+++ b/FakeGatoScheduler.h
@@ -170,6 +170,15 @@ protected:
                                   PROG_CMD_WEEK_SCHEDULE &out, int offsetMin);
   void convertEveSlotsToUTC(int utcOffsetMin);
 
+  // Returns the best available UTC offset in minutes (UTC = local + offset).
+  // Returns INT_MIN if the offset cannot be determined.
+  int getEffectiveOffsetMin() const;
+
+  // Round-trips prog_send_data.weekSchedule through UTC→local→UTC.
+  // Any slot that would exceed 3 per local day is dropped from storage so
+  // every stored slot is visible and controllable from the Eve app.
+  void sanitizeScheduleToLocalLimit(int offsetMin);
+
   struct PROG_CMD_CURRENT_SCHEDULE {
     uint8_t header = CURRENT_SCHEDULE;
     CMD_DAY_SCHEDULE current;

--- a/FakeGatoScheduler.h
+++ b/FakeGatoScheduler.h
@@ -128,7 +128,15 @@ protected:
   // Set via setScheduleUtcMode(true) from begin() after the schedVersion
   // migration check in Phase 3.
   bool _scheduleIsUtc = false;
-  
+
+  // UTC offset in minutes computed from the Eve CURRENT_TIME TLV vs system UTC.
+  // Sign convention: UTC = Eve_local + _lastKnownUtcOffsetMin
+  // Example: PST (UTC-8) → Eve sends 07:00, sysUTC=15:00 → offset = +480.
+  int _lastKnownUtcOffsetMin = 0;
+  // True once a valid offset has been established from CURRENT_TIME or inline recompute.
+  // convertEveSlotsToUTC is skipped until this is set to avoid treating local as UTC.
+  bool _utcOffsetKnown = false;
+
   struct PROG_CMD_SCHEDULE_STATE {
     uint8_t header = SCHEDULE_STATE;
     uint8_t schedule_on = 0;  // 00 Schedule off, 01 schedule on
@@ -155,7 +163,13 @@ protected:
     uint8_t header = WEEK_SCHEDULE;
     CMD_DAY_SCHEDULE day[7];
   };
-  
+
+  // General slot offset converter: reads 'in', applies offsetMin, writes cleared+filled 'out'.
+  // Use positive offsetMin for local→UTC (UTC = local + offset) and negative for UTC→local.
+  static void convertSlotsOffset(const PROG_CMD_WEEK_SCHEDULE &in,
+                                  PROG_CMD_WEEK_SCHEDULE &out, int offsetMin);
+  void convertEveSlotsToUTC(int utcOffsetMin);
+
   struct PROG_CMD_CURRENT_SCHEDULE {
     uint8_t header = CURRENT_SCHEDULE;
     CMD_DAY_SCHEDULE current;

--- a/FakeGatoScheduler.h
+++ b/FakeGatoScheduler.h
@@ -39,6 +39,10 @@ public:
   bool enabled() { return scheduleActive; }
   void setEnabled(bool enable);
 
+  // Phase 3 calls this after the schedVersion NVS migration to indicate that
+  // stored slots are UTC and learner-generated schedules may be applied.
+  void setScheduleUtcMode(bool utc) { _scheduleIsUtc = utc; }
+
   static String getSchedulerState(int state); // Return the state as a string
 
   // When the Service recieves Eve Program Data,
@@ -116,7 +120,14 @@ protected:
   uint8_t temperature_offset = 0;
   int currentScheduleDay = -1;
   
-  bool scheduleActive;
+  bool scheduleActive;  // legacy name; new private members use underscore prefix
+
+  // True once Phase 3 has verified stored slots are UTC.
+  // Learner-generated schedules (which are UTC) must not be applied to the
+  // firing path until the scheduler itself is also UTC-aware.
+  // Set via setScheduleUtcMode(true) from begin() after the schedVersion
+  // migration check in Phase 3.
+  bool _scheduleIsUtc = false;
   
   struct PROG_CMD_SCHEDULE_STATE {
     uint8_t header = SCHEDULE_STATE;

--- a/Logger/navien_bootstrap.py
+++ b/Logger/navien_bootstrap.py
@@ -25,7 +25,7 @@ Usage:
 import argparse
 import json
 import sys
-from datetime import date as _date
+from datetime import datetime as _datetime, timezone as _timezone
 
 import config
 import navien_schedule_learner as nsl
@@ -93,17 +93,14 @@ def main():
     # Bootstrap always uses a full-year window so all available history is included
     args.window_weeks = 52
 
-    today = _date.today()
+    today = _datetime.now(_timezone.utc).date()
     years = [today.year - i for i in range(len(args.recency_weights))]
     print(f"Bootstrap mode: window_weeks=52 (full year per recency entry)")
     print(f"Years: {years}  Weights: {args.recency_weights}")
 
-    local_tz, tz_name = nsl.detect_local_timezone()
-    print(f"Timezone: {tz_name}")
-
     print(f"Querying InfluxDB ({args.influxdb_host}:{args.influxdb_port}/{args.influxdb_db}) "
           f"for full-history cold-start events...")
-    events = nsl.fetch_consumption_events(args, local_tz)
+    events = nsl.fetch_consumption_events(args)
     if not events:
         print("No events found. Check InfluxDB connection.")
         sys.exit(1)

--- a/Logger/navien_bucket_export.py
+++ b/Logger/navien_bucket_export.py
@@ -27,20 +27,20 @@ Timing constraint:
 import argparse
 import json
 import sys
-from datetime import date as _date
+from datetime import datetime as _datetime, timezone as _timezone
 
 import config
 import navien_schedule_learner as nsl
 
 
-def build_bucket_payload(args, local_tz, replace=False):
+def build_bucket_payload(args, replace=False):
     """
     Fetch cold-start events from InfluxDB, convert them to 5-minute buckets,
     and build the sparse JSON payload for POST /buckets.
 
     Returns a dict ready for json.dumps().
     """
-    events = nsl.fetch_consumption_events(args, local_tz)
+    events = nsl.fetch_consumption_events(args)
     if not events:
         print("No events found. Check InfluxDB connection.")
         sys.exit(1)
@@ -64,8 +64,8 @@ def build_bucket_payload(args, local_tz, replace=False):
             days.append({"dow": dow, "buckets": buckets})
 
     return {
-        "schema_version": 1,
-        "current_year":   _date.today().year,
+        "schema_version": 2,
+        "current_year":   _datetime.now(_timezone.utc).year,
         "replace":        replace,
         "days":           days,
     }
@@ -167,18 +167,15 @@ def main():
     args.preheat_minutes = nsl.DEFAULT_PREHEAT_MINUTES
     args.gap_minutes     = nsl.DEFAULT_GAP_MINUTES
 
-    today = _date.today()
+    today = _datetime.now(_timezone.utc).date()
     years = [today.year - i for i in range(len(args.recency_weights))]
     print(f"Bootstrap mode: window_weeks=52 (full year per recency entry)")
     print(f"Years: {years}  Weights: {args.recency_weights}")
 
-    local_tz, tz_name = nsl.detect_local_timezone()
-    print(f"Timezone: {tz_name}")
-
     print(f"Querying InfluxDB ({args.influxdb_host}:{args.influxdb_port}/{args.influxdb_db}) "
           f"for full-history cold-start events...")
 
-    payload = build_bucket_payload(args, local_tz, replace=args.replace)
+    payload = build_bucket_payload(args, replace=args.replace)
 
     total = sum(len(d["buckets"]) for d in payload["days"])
     payload_json = json.dumps(payload)

--- a/Logger/navien_schedule_learner.py
+++ b/Logger/navien_schedule_learner.py
@@ -23,41 +23,9 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import config   # Navien shared config (rates, InfluxDB connection, timing)
 
-
-# ---------------------------------------------------------------------------
-# Timezone detection
-# ---------------------------------------------------------------------------
-def detect_local_timezone():
-    """
-    Read the system timezone from /etc/timezone (Debian/Raspberry Pi OS standard).
-    Falls back to UTC with a warning if the file is missing or unreadable.
-    """
-    try:
-        with open("/etc/timezone") as f:
-            tz_name = f.read().strip()
-        tz = ZoneInfo(tz_name)
-        return tz, tz_name
-    except (FileNotFoundError, ZoneInfoNotFoundError):
-        pass
-
-    # Fallback: try the /etc/localtime symlink target
-    import os
-    try:
-        link = os.readlink("/etc/localtime")
-        # e.g. /usr/share/zoneinfo/America/Los_Angeles
-        tz_name = "/".join(link.split("/")[-2:])
-        tz = ZoneInfo(tz_name)
-        return tz, tz_name
-    except (OSError, ZoneInfoNotFoundError):
-        pass
-
-    print("[timezone] WARNING: Could not detect system timezone. Defaulting to UTC.")
-    print("[timezone] Set your Pi's timezone with: sudo raspi-config → Localisation Options")
-    return timezone.utc, "UTC"
 
 # ---------------------------------------------------------------------------
 # Configuration defaults  (override via CLI args)
@@ -158,7 +126,7 @@ def _format_influx_time_utc(dt):
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _extract_cold_starts(points, local_tz, recency_weight, cold_gap_minutes,
+def _extract_cold_starts(points, recency_weight, cold_gap_minutes,
                           min_duration_genuine, min_duration_recirc,
                           verbose=False):
     """
@@ -185,7 +153,7 @@ def _extract_cold_starts(points, local_tz, recency_weight, cold_gap_minutes,
     Run duration is measured as the number of consecutive active minutes
     following the cold-start before a gap appears.
 
-    Returns a list of (dt_local, combined_weight) tuples.
+    Returns a list of (dt_utc, combined_weight) tuples.
     """
     from datetime import timedelta
 
@@ -254,25 +222,24 @@ def _extract_cold_starts(points, local_tz, recency_weight, cold_gap_minutes,
 
         combined_weight = recency_weight * demand_weight * cost_multiplier
 
-        ts_str2  = start_ts.rstrip("Z")
-        dt_utc   = datetime.fromisoformat(ts_str2).replace(tzinfo=timezone.utc)
-        dt_local = dt_utc.astimezone(local_tz)
-        cold_starts.append((dt_local, combined_weight))
+        ts_str2 = start_ts.rstrip("Z")
+        dt_utc  = datetime.fromisoformat(ts_str2).replace(tzinfo=timezone.utc)
+        cold_starts.append((dt_utc, combined_weight))
 
         if verbose:
             tag = ("recirc-on" if recirc_on else "cold-pipe")
             dur_sec = duration * 10
             dur_str = f"{dur_sec//60}min{dur_sec%60:02d}s" if dur_sec < 3600 else f"{dur_sec//3600}h{(dur_sec%3600)//60}min"
-            print(f"  cold-start {dt_local.strftime('%Y-%m-%d %H:%M')} "
+            print(f"  cold-start {dt_utc.strftime('%Y-%m-%d %H:%M UTC')} "
                   f"dur={dur_str} {tag} demand_w={demand_weight:.1f} "
                   f"cost_mult={cost_multiplier:.3f} combined_w={combined_weight:.2f}")
 
     return cold_starts
 
 
-def fetch_consumption_events(args, local_tz):
+def fetch_consumption_events(args):
     """
-    Returns a list of (local_datetime, weight) tuples representing cold-start
+    Returns a list of (utc_datetime, weight) tuples representing cold-start
     events: the first tap-on after ≥cold_gap_minutes of inactivity, across
     the rolling ±window_weeks seasonal band for all configured years.
 
@@ -287,7 +254,6 @@ def fetch_consumption_events(args, local_tz):
     dominate the learned schedule.
     """
     from influxdb import InfluxDBClient
-    from datetime import date
 
     client = InfluxDBClient(
         host=args.influxdb_host,
@@ -297,7 +263,7 @@ def fetch_consumption_events(args, local_tz):
         database=args.influxdb_db,
     )
 
-    today        = date.today()
+    today        = datetime.now(timezone.utc).date()
     weights      = args.recency_weights
     current_year = today.year
 
@@ -364,7 +330,7 @@ def fetch_consumption_events(args, local_tz):
         points = sorted(points_by_time.values(), key=lambda p: p["time"])
         active_count = sum(1 for p in points if p.get("consumption_active") == 1)
         cold_starts = _extract_cold_starts(
-            points, local_tz, weight,
+            points, weight,
             cold_gap_minutes=args.cold_gap_minutes,
             min_duration_genuine=args.min_duration_genuine,
             min_duration_recirc=args.min_duration_recirc,
@@ -384,7 +350,7 @@ def fetch_consumption_events(args, local_tz):
 # ---------------------------------------------------------------------------
 def events_to_minutes(events, verbose=False):
     """
-    Convert a list of (local_datetime, weight) tuples into two parallel dicts,
+    Convert a list of (utc_datetime, weight) tuples into two parallel dicts,
     both keyed by day-of-week (0=Sun..6=Sat) then by 5-minute bucket:
 
       raw_counts[dow][bucket]      — unweighted hit count (used for min_occurrences filter)
@@ -407,7 +373,7 @@ def events_to_minutes(events, verbose=False):
         weighted_scores[dow][bucket] += weight
 
     if verbose:
-        print("\n[debug] Raw bucket hit counts per day (local time):")
+        print("\n[debug] Raw bucket hit counts per day (UTC):")
         for dow in range(7):
             hot = sorted((b, c) for b, c in raw_counts.get(dow, {}).items())
             if hot:
@@ -678,8 +644,8 @@ def estimate_schedule_cost(week, raw_counts, weighted_scores,
     For each day of the coming week, compute reframed efficiency.
     Returns a list of 7 dicts (index 0 = Sunday).
     """
-    from datetime import date, timedelta
-    today = date.today()
+    from datetime import timedelta
+    today = datetime.now(timezone.utc).date()
     coming_week = []
     for offset in range(7):
         d      = today + timedelta(days=offset)
@@ -910,13 +876,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Step 0: Detect local timezone
-    local_tz, tz_name = detect_local_timezone()
-    print(f"Using timezone: {tz_name}")
-
     # Step 1: Fetch cold-start events from InfluxDB (rolling window, all years)
-    from datetime import date as _date
-    today = _date.today()
+    today = datetime.now(timezone.utc).date()
     print(f"Querying InfluxDB ({args.influxdb_host}:{args.influxdb_port}/{args.influxdb_db}) "
           f"— rolling ±{args.window_weeks}-week window around "
           f"{today.strftime('%b %d')}, years weighted {args.recency_weights}...")
@@ -925,7 +886,7 @@ def main():
           f"genuine threshold: {args.min_duration_genuine} buckets cold / "
           f"{args.min_duration_recirc} buckets with recirc "
           f"[10s resolution: ×6=min, ×3=30s])...")
-    events = fetch_consumption_events(args, local_tz)
+    events = fetch_consumption_events(args)
 
     if not events:
         print("No cold-start events found. Check your InfluxDB connection and database name.")
@@ -935,8 +896,8 @@ def main():
     print(f"Found {len(events)} cold-start events across "
           f"{len(args.recency_weights)} year(s) of seasonal data.")
     if args.verbose:
-        print(f"  First event (local): {dts[0].strftime('%Y-%m-%d %H:%M %Z')}")
-        print(f"  Last event  (local): {dts[-1].strftime('%Y-%m-%d %H:%M %Z')}")
+        print(f"  First event (UTC): {dts[0].strftime('%Y-%m-%d %H:%M %Z')}")
+        print(f"  Last event  (UTC): {dts[-1].strftime('%Y-%m-%d %H:%M %Z')}")
 
     # Step 2: Bin into per-day-of-week buckets (raw counts + weighted scores)
     raw_counts, weighted_scores = events_to_minutes(events, verbose=args.verbose)
@@ -951,8 +912,7 @@ def main():
         day_raw      = raw_counts.get(dow, {})
         day_weighted = weighted_scores.get(dow, {})
         total_years  = len(args.recency_weights)
-        from datetime import date as _date2
-        _today = _date2.today()
+        _today = datetime.now(timezone.utc).date()
         print(f"\n=== Debug: {day_name} (±{args.window_weeks}wk window around "
               f"{_today.strftime('%b %d')}, {total_years} years, "
               f"weights={args.recency_weights}) ===")

--- a/NavienLearner.cpp
+++ b/NavienLearner.cpp
@@ -75,7 +75,7 @@ NavienLearner::NavienLearner()
       _recomputeRequested(false),
       _taskState(IDLE),
       _recomputeDay(0),
-      _lastRecomputeYday(-1),
+      _lastRecomputeTime24h(0),
       _startupDecayDone(false),
       _lastRecomputeTime(0),
       _scheduleHandoffMutex(nullptr),
@@ -168,9 +168,9 @@ void NavienLearner::onNavienState(bool consumption_active,
 
         if (isColdStart) {
             // Pin dow and bucket to tap-open time.
-            struct tm *t = localtime(&now);
-            _runDow    = t->tm_wday;                          // 0=Sun
-            _runBucket = (t->tm_hour * 60 + t->tm_min) / 5;  // 0–287
+            struct tm *t = gmtime(&now);
+            _runDow    = t->tm_wday;                          // 0=Sun (UTC)
+            _runBucket = (t->tm_hour * 60 + t->tm_min) / 5;  // 0–287 (UTC)
 
             _runStart        = now;
             _runDurationSec  = 0;
@@ -237,26 +237,31 @@ void NavienLearner::advanceMeasuredWeek() {
 
 // On-disk layout for measured.bin
 struct MeasuredFile {
-    uint32_t    magic;           // 0x4D454153 ("MEAS")
-    uint8_t     schema_version;  // bump if struct layout changes
-    uint8_t     head;            // _measuredHead (0–3)
+    uint32_t    magic;              // 0x4D454153 ("MEAS")
+    uint8_t     schema_version;     // bump if struct layout changes
+    uint8_t     head;               // _measuredHead (0–3)
     uint8_t     pad[2];
     WeekMeasured measured[4];
+    // int64_t used so the field survives if time_t widens beyond 32 bits on a
+    // future toolchain.  On ESP32 Arduino time_t is signed 32-bit; values above
+    // 2^31-1 (year 2038) are not supported by the platform regardless.
+    int64_t     last_recompute_24h; // _lastRecomputeTime24h (epoch seconds); survives reboots
 };
 
 static constexpr uint32_t MEASURED_MAGIC          = 0x4D454153u;
-static constexpr uint8_t  MEASURED_SCHEMA_VERSION = 1;
+static constexpr uint8_t  MEASURED_SCHEMA_VERSION = 2;
 static constexpr char     MEASURED_FILE[]         = "/navien/measured.bin";
 static constexpr char     MEASURED_TMP_FILE[]     = "/navien/measured.tmp";
 
 bool NavienLearner::saveMeasured() {
     MeasuredFile mf;
-    mf.magic          = MEASURED_MAGIC;
-    mf.schema_version = MEASURED_SCHEMA_VERSION;
-    mf.head           = _measuredHead;
-    mf.pad[0]         = 0;
-    mf.pad[1]         = 0;
+    mf.magic              = MEASURED_MAGIC;
+    mf.schema_version     = MEASURED_SCHEMA_VERSION;
+    mf.head               = _measuredHead;
+    mf.pad[0]             = 0;
+    mf.pad[1]             = 0;
     memcpy(mf.measured, _measured, sizeof(_measured));
+    mf.last_recompute_24h = (int64_t)_lastRecomputeTime24h;
 
     File f = LittleFS.open(MEASURED_TMP_FILE, "w");
     if (!f) {
@@ -318,7 +323,8 @@ bool NavienLearner::loadMeasured() {
     }
 
     memcpy(_measured, mf.measured, sizeof(_measured));
-    _measuredHead = mf.head;
+    _measuredHead         = mf.head;
+    _lastRecomputeTime24h = (time_t)mf.last_recompute_24h;
     Serial.printf("NavienLearner: measured window loaded (head=%u)\n", mf.head);
     return true;
 }
@@ -430,19 +436,30 @@ void NavienLearner::idleStep() {
         return;
     }
 
-    // Midnight + 2min check: trigger nightly recompute once per day.
+    // 24h elapsed timer: trigger nightly recompute once per day.
     // Goes via DECAY_CHECK first so year-rollover decay is applied before
     // the new schedule is computed.
     time_t now = time(nullptr);
-    if (now > 0) {
-        struct tm tm_buf;
-        struct tm *t = localtime_r(&now, &tm_buf);
-        if (t->tm_hour == 0 && t->tm_min >= 2 &&
-            t->tm_yday != _lastRecomputeYday) {
-            _lastRecomputeYday = t->tm_yday;
-            // Sunday midnight: advance the measured efficiency week slot.
+    if (now > 1700000000L) {  // require a plausible NTP-synced epoch, not just any positive value
+        if (_lastRecomputeTime24h == 0) {
+            // First eligible tick after boot (or missing measured.bin).
+            // Persist immediately so a reboot in the first 24h window still
+            // anchors from this point rather than from zero again.
+            _lastRecomputeTime24h = now;
+            saveMeasured();
+        }
+        // Guard against NTP backward jumps resetting the anchor into the future;
+        // a forward jump is harmless (fires one recompute early at most).
+        if (_lastRecomputeTime24h > now) _lastRecomputeTime24h = now;
+        if (now - _lastRecomputeTime24h >= 86400L) {
+            _lastRecomputeTime24h = now;
+            struct tm tm_buf;
+            struct tm *t = gmtime_r(&now, &tm_buf);
+            // UTC Sunday: advance the measured efficiency week slot.
             if (t->tm_wday == 0) {
-                advanceMeasuredWeek();
+                advanceMeasuredWeek();  // advanceMeasuredWeek calls saveMeasured()
+            } else {
+                saveMeasured();  // persist the updated 24h anchor between weekly saves
             }
             _taskState = DECAY_CHECK;
         }
@@ -473,7 +490,7 @@ void NavienLearner::decayCheck() {
     }
 
     struct tm  tm_buf;
-    struct tm *t        = localtime_r(&now, &tm_buf);
+    struct tm *t        = gmtime_r(&now, &tm_buf);
     uint16_t  this_year = (uint16_t)(t->tm_year + 1900);
     uint16_t  stored_year = _store.data().current_year;
 
@@ -653,7 +670,7 @@ int NavienLearner::ingestBucketPayload(const char *json, bool &replaced) {
         // BucketStore::begin() so the header is never left at a stale value.
         if (current_year <= 0) {
             time_t now = time(nullptr);
-            struct tm *t = localtime(&now);
+            struct tm *t = gmtime(&now);
             current_year = (t && t->tm_year > 100) ? (t->tm_year + 1900) : 2025;
         }
         bf.current_year = (uint16_t)current_year;
@@ -781,7 +798,7 @@ void NavienLearner::appendStatusHTML(String &page) const {
     if (_lastRecomputeTime > 0) {
         char tbuf[32];
         struct tm  tm_buf;
-        struct tm *t = localtime_r(&_lastRecomputeTime, &tm_buf);
+        struct tm *t = localtime_r(&_lastRecomputeTime, &tm_buf);  // display only
         strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M", t);
         time_t elapsed = time(nullptr) - _lastRecomputeTime;
         char abuf[32];

--- a/NavienLearner.h
+++ b/NavienLearner.h
@@ -175,7 +175,7 @@ private:
     volatile bool _recomputeRequested;  // set from any core, cleared on Core 0
     TaskState     _taskState;
     int           _recomputeDay;        // 0–6; current day being processed in RECOMPUTING
-    int           _lastRecomputeYday;   // tm_yday of last midnight recompute trigger (-1 = never)
+    time_t        _lastRecomputeTime24h; // wall time of last 24h recompute trigger (0 = never)
     bool          _startupDecayDone;    // true once the one-shot startup decay check has run
     time_t        _lastRecomputeTime;   // wall time of last RECOMPUTE_WRITE (0 = never)
 

--- a/NavienManager.ino
+++ b/NavienManager.ino
@@ -111,10 +111,9 @@ void loop() {
     loopScheduleEndpoint();
   }
 
-  // Check for system clock setup, which the SchedulerBase class does
-  if (!timeInit && getenv("TZ")){
-    struct tm localTime;
-    if (getLocalTime(&localTime)) { // getLocalTime() returns non-zero if initialized
+  // Gate HomeSpan time on a plausible NTP-synced epoch; TZ is no longer required.
+  if (!timeInit) {
+    if (time(nullptr) > 1700000000L) {
       timeInit = true;
       homeSpan.assumeTimeAcquired();
     }

--- a/SchedulerBase.cpp
+++ b/SchedulerBase.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "SchedulerBase.h"
+#include "TimeUtils.h"
 #include "esp_netif_sntp.h"
 #include <WiFi.h>
 
@@ -154,7 +155,7 @@ SchedulerBase::State SchedulerBase::getNextState(time_t *nextStateTime) const {
     }
     
       // Check if we'll be in an active slot when vacation ends
-    struct tm *end_tm = localtime(&endVacationTime);
+    struct tm *end_tm = gmtime(&endVacationTime);
     int endHour = end_tm->tm_hour;
     int endMinute = end_tm->tm_min;
     int endDay = end_tm->tm_wday;
@@ -170,12 +171,12 @@ SchedulerBase::State SchedulerBase::getNextState(time_t *nextStateTime) const {
   
     // Find the next event
   time_t now = time(nullptr);
-  struct tm *tm_struct = localtime(&now);
-  
+  struct tm *tm_struct = gmtime(&now);
+
   int currentHour = tm_struct->tm_hour;
   int currentMinute = tm_struct->tm_min;
   int currentDay = tm_struct->tm_wday;
-  
+
   int currentTimeInMinutes = currentHour * 60 + currentMinute;
   
   for (int dayoffset = 0; dayoffset < 7; dayoffset++) {
@@ -191,8 +192,8 @@ SchedulerBase::State SchedulerBase::getNextState(time_t *nextStateTime) const {
         nextState_tm.tm_hour = weekSchedule[day].slots[slot].startHour;
         nextState_tm.tm_min = weekSchedule[day].slots[slot].startMinute;
         nextState_tm.tm_sec = 0;
-        nextState_tm.tm_isdst = -1; // Use TZ to determine DST offsets.
-        nextTime = mktime(&nextState_tm);
+        nextState_tm.tm_isdst = 0;
+        nextTime = proper_timegm(&nextState_tm);
         if (startVacationTime && startVacationTime < nextTime) {
           if (nextStateTime) {
             *nextStateTime = startVacationTime;
@@ -214,8 +215,8 @@ SchedulerBase::State SchedulerBase::getNextState(time_t *nextStateTime) const {
         nextState_tm.tm_hour = weekSchedule[day].slots[slot].endHour;
         nextState_tm.tm_min = weekSchedule[day].slots[slot].endMinute;
         nextState_tm.tm_sec = 0;
-        nextState_tm.tm_isdst = -1; // Use TZ to determine DST offsets.
-        nextTime = mktime(&nextState_tm);
+        nextState_tm.tm_isdst = 0;
+        nextTime = proper_timegm(&nextState_tm);
         if (startVacationTime && startVacationTime < nextTime) {
           if (nextStateTime) {
             *nextStateTime = startVacationTime;
@@ -352,7 +353,7 @@ int SchedulerBase::begin() {
   status = nvs_get_str(nvsStorageHandle, "TZ", tzStr, &len);
   if (status) {
     Serial.printf("Failed to load TZ from NVS: %s.\n", esp_err_to_name(status));
-    Serial.println("Schedules won't run until TZ set.");
+    Serial.println("TZ not set; schedule firing does not require TZ (display-only).");
   } else {
     tz = tzStr;
     Serial.print("Restoring saved TZ: ");
@@ -387,7 +388,7 @@ void SchedulerBase::initializeCurrentState() {
   }
   // Finally check if we're in an active time slot
   else {
-    struct tm *tm_struct = localtime(&now);
+    struct tm *tm_struct = gmtime(&now);
     int currentHour = tm_struct->tm_hour;
     int currentMinute = tm_struct->tm_min;
     int currentDay = tm_struct->tm_wday;
@@ -430,12 +431,6 @@ void SchedulerBase::loop() {
     return;
   }
   
-  // No timezone set, so we can't schedule.
-  if (getenv("TZ") == 0) {
-    isInitialized = false;
-    return;
-  }
-
   // If we just became initialized, determine our current state
   if (!isInitialized) {
     isInitialized = true;

--- a/TelnetCommands.cpp
+++ b/TelnetCommands.cpp
@@ -368,6 +368,7 @@ void commandScheduler(const String& params) {
     struct SlotDisplay {
       int lsh, lsm, leh, lem;
       int sh, sm, eh, em;
+      int dayShift;  // -1 = fires previous local day, 0 = same day, +1 = next local day
     } slots[3];
     int slotCount = 0;
 
@@ -376,6 +377,7 @@ void commandScheduler(const String& params) {
       if (!scheduler->getTimeSlot(day, slot, sh, sm, eh, em)) continue;
       SlotDisplay &s = slots[slotCount++];
       s.sh = sh; s.sm = sm; s.eh = eh; s.em = em;
+      s.dayShift = 0;
       if (tzKnown) {
         // Slots are stored in UTC; convert to local using a fixed reference
         // date (Jan 2 1970) so only the hour:min offset matters.
@@ -389,6 +391,10 @@ void commandScheduler(const String& params) {
         time_t te = proper_timegm(&ref);
         struct tm *le = localtime(&te);
         s.leh = le->tm_hour; s.lem = le->tm_min;
+        // Detect midnight rollover: compare local vs UTC start in minutes.
+        int diff = (s.lsh * 60 + s.lsm) - (sh * 60 + sm);
+        if (diff >  720) s.dayShift = -1; // local is previous day (e.g. UTC 04:00 → local 21:00)
+        if (diff < -720) s.dayShift = +1; // local is next day
       }
     }
 
@@ -407,11 +413,13 @@ void commandScheduler(const String& params) {
 
     for (int i = 0; i < slotCount; i++) {
       SlotDisplay &s = slots[i];
-      if (tzKnown)
-        telnet.printf(" %02d:%02d-%02d:%02d (UTC %02d:%02d-%02d:%02d)",
-                      s.lsh, s.lsm, s.leh, s.lem, s.sh, s.sm, s.eh, s.em);
-      else
+      if (tzKnown) {
+        telnet.printf(" %02d:%02d-%02d:%02d (UTC %02d:%02d-%02d:%02d%s)",
+                      s.lsh, s.lsm, s.leh, s.lem, s.sh, s.sm, s.eh, s.em,
+                      s.dayShift == -1 ? ", prev day" : s.dayShift == +1 ? ", next day" : "");
+      } else {
         telnet.printf(" %02d:%02d-%02d:%02d (UTC)", s.sh, s.sm, s.eh, s.em);
+      }
     }
     if (slotCount == 0) telnet.print(" (none)");
     telnet.println();

--- a/TelnetCommands.cpp
+++ b/TelnetCommands.cpp
@@ -30,6 +30,7 @@ SOFTWARE.
 #include "FakeGatoHistoryService.h"
 #include "FakeGatoScheduler.h"
 #include "NavienLearner.h"
+#include "TimeUtils.h"
 
 ESPTelnet telnet;
 extern Navien navienSerial;
@@ -359,18 +360,60 @@ void commandScheduler(const String& params) {
     telnet.println("Next transition:  None scheduled");
   }
 
+  bool tzKnown = (getenv("TZ") != nullptr);
   telnet.println("Weekly schedule:");
   for (int day = 0; day < 7; day++) {
     telnet.printf("  %s:", dayNames[day]);
-    bool hasSlots = false;
+
+    struct SlotDisplay {
+      int lsh, lsm, leh, lem;
+      int sh, sm, eh, em;
+    } slots[3];
+    int slotCount = 0;
+
     for (int slot = 0; slot < 3; slot++) {
       uint8_t sh, sm, eh, em;
-      if (scheduler->getTimeSlot(day, slot, sh, sm, eh, em)) {
-        telnet.printf(" %02d:%02d-%02d:%02d", sh, sm, eh, em);
-        hasSlots = true;
+      if (!scheduler->getTimeSlot(day, slot, sh, sm, eh, em)) continue;
+      SlotDisplay &s = slots[slotCount++];
+      s.sh = sh; s.sm = sm; s.eh = eh; s.em = em;
+      if (tzKnown) {
+        // Slots are stored in UTC; convert to local using a fixed reference
+        // date (Jan 2 1970) so only the hour:min offset matters.
+        struct tm ref = {};
+        ref.tm_year = 70; ref.tm_mon = 0; ref.tm_mday = 2; ref.tm_sec = 0;
+        ref.tm_hour = sh; ref.tm_min = sm;
+        time_t ts = proper_timegm(&ref);
+        struct tm *ls = localtime(&ts);
+        s.lsh = ls->tm_hour; s.lsm = ls->tm_min;
+        ref.tm_hour = eh; ref.tm_min = em;
+        time_t te = proper_timegm(&ref);
+        struct tm *le = localtime(&te);
+        s.leh = le->tm_hour; s.lem = le->tm_min;
       }
     }
-    if (!hasSlots) telnet.print(" (none)");
+
+    // Sort by local start time (insertion sort; max 3 elements).
+    if (tzKnown) {
+      for (int i = 1; i < slotCount; i++) {
+        SlotDisplay key = slots[i];
+        int j = i - 1;
+        while (j >= 0 && (slots[j].lsh * 60 + slots[j].lsm) > (key.lsh * 60 + key.lsm)) {
+          slots[j + 1] = slots[j];
+          j--;
+        }
+        slots[j + 1] = key;
+      }
+    }
+
+    for (int i = 0; i < slotCount; i++) {
+      SlotDisplay &s = slots[i];
+      if (tzKnown)
+        telnet.printf(" %02d:%02d-%02d:%02d (UTC %02d:%02d-%02d:%02d)",
+                      s.lsh, s.lsm, s.leh, s.lem, s.sh, s.sm, s.eh, s.em);
+      else
+        telnet.printf(" %02d:%02d-%02d:%02d (UTC)", s.sh, s.sm, s.eh, s.em);
+    }
+    if (slotCount == 0) telnet.print(" (none)");
     telnet.println();
   }
 }

--- a/TimeUtils.cpp
+++ b/TimeUtils.cpp
@@ -1,0 +1,21 @@
+#include "TimeUtils.h"
+
+// Days from civil (Gregorian) date to Unix epoch (1970-01-01 = day 0).
+// Algorithm: Howard Hinnant — https://howardhinnant.github.io/date_algorithms.html
+// "days_from_civil", reproduced verbatim in integer arithmetic.
+static long days_from_civil(int y, int m, int d) {
+    y -= (m <= 2);
+    const long era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = (unsigned)(y - era * 400L);
+    const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + (unsigned)d - 1;
+    const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    return era * 146097L + (long)doe - 719468L;
+}
+
+time_t proper_timegm(const struct tm *t) {
+    const long days = days_from_civil(t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
+    return (time_t)(days * 86400L
+                  + (long)t->tm_hour * 3600L
+                  + (long)t->tm_min  * 60L
+                  + (long)t->tm_sec);
+}

--- a/TimeUtils.h
+++ b/TimeUtils.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <time.h>
+
+// TZ-free equivalent of timegm(). Converts a UTC struct tm to time_t using
+// pure integer arithmetic — no setenv("TZ"), no mktime(), no floating point.
+//
+// Supported range on ESP32 Arduino (signed 32-bit time_t):
+//   1970-01-01 00:00:00 UTC  →  0
+//   2038-01-19 03:14:07 UTC  →  INT32_MAX (2147483647)
+// Inputs outside this range produce undefined (overflowed) results.
+time_t proper_timegm(const struct tm *t);

--- a/TimeUtils_test.cpp
+++ b/TimeUtils_test.cpp
@@ -1,0 +1,53 @@
+// Host-side test harness for proper_timegm().
+// Compile and run:
+//   g++ -o TimeUtils_test TimeUtils_test.cpp TimeUtils.cpp && ./TimeUtils_test
+
+#include "TimeUtils.h"
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+struct TestCase {
+    const char *label;
+    int y, mo, d, h, mi, s;
+    long long expected;
+};
+
+static const TestCase cases[] = {
+    { "Unix epoch",                          1970,  1,  1,  0,  0,  0,          0LL },
+    { "1970-12-31 23:59:59 UTC",             1970, 12, 31, 23, 59, 59,   31535999LL },
+    { "2025-01-01 00:00:00 UTC",             2025,  1,  1,  0,  0,  0, 1735689600LL },
+    // PST→PDT spring-forward: clocks move 02:00→03:00 PST on this UTC instant
+    { "2025-03-09 10:00:00 UTC (DST ref)",   2025,  3,  9, 10,  0,  0, 1741514400LL },
+    // Half-hour offset: 2025-07-01 02:30 UTC = noon in UTC+9:30
+    { "2025-07-01 02:30:00 UTC (+9:30 ref)", 2025,  7,  1,  2, 30,  0, 1751337000LL },
+    { "2024-02-29 12:00:00 UTC (leap day)",  2024,  2, 29, 12,  0,  0, 1709208000LL },
+    // INT32_MAX — upper limit on ESP32 Arduino signed 32-bit time_t
+    { "2038-01-19 03:14:07 UTC (INT32_MAX)", 2038,  1, 19,  3, 14,  7, 2147483647LL },
+};
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        const TestCase &tc = cases[i];
+        struct tm t;
+        memset(&t, 0, sizeof(t));
+        t.tm_year = tc.y - 1900;
+        t.tm_mon  = tc.mo - 1;
+        t.tm_mday = tc.d;
+        t.tm_hour = tc.h;
+        t.tm_min  = tc.mi;
+        t.tm_sec  = tc.s;
+        long long got = (long long)proper_timegm(&t);
+        if (got == tc.expected) {
+            printf("PASS  %-42s  %lld\n", tc.label, got);
+        } else {
+            printf("FAIL  %-42s  expected %lld, got %lld\n", tc.label, tc.expected, got);
+            ++failures;
+        }
+    }
+    printf("\n%s  (%d failure%s)\n",
+           failures == 0 ? "ALL PASSED" : "FAILED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}

--- a/UTC_MIGRATION_PLAN.md
+++ b/UTC_MIGRATION_PLAN.md
@@ -34,18 +34,22 @@ A TZ-free `timegm()` equivalent. The current `timegm()` hack in `FakeGatoSchedul
 #pragma once
 #include <time.h>
 time_t proper_timegm(const struct tm *t);
+```
 
-// TimeUtils.cpp
+> **Sketch only — do not implement as shown.** The snippet below uses `30.6001` floating-point, which Phase 1 explicitly rejects in favour of integer arithmetic. Follow Phase 1's implementation guidance; the sketch is retained only to illustrate the algorithm structure.
+
+```cpp
+// TimeUtils.cpp — ILLUSTRATIVE ONLY; use integer Fliegel-Van Flandern arithmetic in practice
 time_t proper_timegm(const struct tm *t) {
     int y = t->tm_year + 1900, m = t->tm_mon + 1;
     if (m <= 2) { y--; m += 12; }
     long days = (long)(365 * y) + (y/4) - (y/100) + (y/400)
-              + (long)(30.6001 * (m + 1)) + t->tm_mday - 719591L;
+              + (long)(30.6001 * (m + 1)) + t->tm_mday - 719591L;  // ← replace with integer
     return (time_t)(days * 86400L + t->tm_hour * 3600L + t->tm_min * 60L + t->tm_sec);
 }
 ```
 
-Use a **unit-tested** calendar→epoch implementation (integer mudane / Fliegel–Van Flandern style is preferable to `30.6001` floating‑point) and validate against known `struct tm` ↔ UTC instants on the ESP32 toolchain; `time_t` is signed 32‑bit on many Arduino builds, so document the supported year range.
+Use a **unit-tested** integer calendar→epoch implementation and validate against known `struct tm` ↔ UTC instants on the ESP32 toolchain; `time_t` is signed 32‑bit on many Arduino builds, so document the supported year range.
 
 Include from `SchedulerBase.cpp` and `FakeGatoScheduler.cpp`.
 
@@ -236,29 +240,138 @@ if (!timeInit) {
 
 ---
 
-## Recommended Implementation Order
+## Implementation Phases
 
-1. Create `TimeUtils.h` / `TimeUtils.cpp` with `proper_timegm()`
-2. `FakeGatoScheduler.cpp` — replace `timegm()` hack; add `_lastKnownUtcOffsetMin`; add `convertEveSlotsToUTC()`; wire into `parseProgramData()`; NVS `schedVersion` + migration reset on `SAVED_DATA` before `updateSchedulerWeekSchedule()` in `begin()`; Eve readback UTC→local
-3. `SchedulerBase.cpp` — `gmtime()` + `proper_timegm()` in firing path; remove TZ guard; relax TZ-missing messaging in `begin()`
-4. `NavienLearner.cpp` / `NavienLearner.h` — `gmtime()` for buckets; 24h elapsed timer
-5. `BucketStore.cpp` / `BucketStore.h` — `gmtime()` for year; bump `BUCKET_SCHEMA_VERSION`
-6. `NavienManager.ino` — epoch-based clock gate
-7. Python: `navien_schedule_learner.py` — UTC bucket path; drop `local_tz`
-8. Python: `navien_bootstrap.py` + `navien_bucket_export.py` — drop `local_tz`; send `schema_version: 2`
+The migration is split into four independently flashable phases. Each phase can be verified before starting the next. Phases 2 and 3 each require a post-flash step; Phase 4 is Python-only and requires no firmware flash.
+
+> **Why this order?** Phase 1 proves `proper_timegm()` before anything depends on it. Phase 2 is self-contained (learner/buckets have no schedule dependency). Phase 3 is the highest-risk change and is tackled last on a proven foundation. Phase 4 must be applied before Phase 2's post-flash step 2 (`navien_bucket_export.py --push --replace`) — the device will reject a `schema_version: 1` payload after `BUCKET_SCHEMA_VERSION` is bumped to 2, and the old script produces local-time bucket indices that would contradict the UTC firmware.
 
 ---
 
-## Post-Flash Checklist
+### Phase 1 — Foundation
+**Goal:** Add `proper_timegm()` with no behavioral change. Independently verifiable.
 
-After flashing new firmware:
-1. Verify device boots and connects to WiFi/NTP normally.
-2. Check weblog for the migration reset message (logged from `FakeGatoScheduler` / `SAVED_DATA` path) — confirms slot reset.
-3. Open Eve app → Programs tab → re-save the week schedule (triggers `parseProgramData()` → `convertEveSlotsToUTC()` → NVS write).
-4. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
-5. Run `python3 navien_bootstrap.py --push` if you want the computed schedule re-derived from InfluxDB in UTC.
-6. Verify telnet `schedule` command shows correct local times (confirms UTC→local display conversion).
-7. Verify Eve shows correct schedule times.
+**Files:**
+- `TimeUtils.h` *(new)*
+- `TimeUtils.cpp` *(new)*
+
+**Work:**
+- Implement integer-arithmetic `proper_timegm()` (no `30.6001` float; no TZ env touch).
+- Write table-driven test harness covering: epoch=0, 2025-01-01 00:00 UTC, PST/PDT crossover, UTC+9:30 half-hour zone, year 2038 boundary.
+- Document supported `time_t` year range (ESP32 Arduino: signed 32-bit, overflows 2038).
+
+**Post-flash verification:** Compile-only; no flash needed. Run test harness on host or ESP32 serial.
+
+---
+
+### Phase 2 — Learner & Buckets
+**Goal:** Bucket recording and daily recompute become UTC-based. Completely independent of the schedule system.
+
+**Files:**
+- `NavienLearner.cpp`
+- `NavienLearner.h`
+- `BucketStore.cpp`
+- `BucketStore.h`
+
+**Work:**
+- `onNavienState()` line 171: `localtime` → `gmtime` for `_runDow` and `_runBucket`.
+- `idleStep()` lines 436–448: replace `localtime_r` midnight detection with 24h elapsed timer; UTC Sunday check for `advanceMeasuredWeek()`.
+- `decayCheck()` line 476: `localtime_r` → `gmtime_r`.
+- `ingestBucketPayload()` line 656: `localtime` → `gmtime`.
+- `BucketStore::begin()` line 67: `localtime` → `gmtime`.
+- Bump `BUCKET_SCHEMA_VERSION` to 2 (forces `initEmpty()` on first boot).
+- Bump `MEASURED_SCHEMA_VERSION` to 2 (clean reset; 4-week window repopulates within a week).
+- Replace `_lastRecomputeYday` with `_lastRecomputeTime24h` in `NavienLearner.h` and constructor.
+
+> **Mixed-state note:** Between flashing Phase 2 and Phase 3, buckets are UTC-indexed while schedule firing remains local-time. The two are internally consistent within their own subsystems, but bucket timestamps and slot boundaries will not align until Phase 3 is flashed. This is expected and harmless for the interim period.
+
+**Post-flash steps:**
+1. Verify device boots and weblog shows bucket schema reset.
+2. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
+3. Monitor for 24–48 hours: confirm recompute fires roughly 24h after startup (not at wrong local hour). Note: the first interval is 24h from the first eligible `idleStep()` tick with a valid `now`, not from NTP sync itself — in practice the same order of magnitude but not exact.
+
+---
+
+### Phase 3 — Schedule System
+**Goal:** Schedule slots stored and fired in UTC. Eve write path converts local→UTC; Eve read path converts UTC→local. TZ becomes display-only.
+
+**Must ship as a single flash** — changing the firing path to expect UTC slots and the write path to store UTC slots must be atomic.
+
+**Files:**
+- `TimeUtils.h` / `TimeUtils.cpp` *(Phase 1 prerequisite)*
+- `FakeGatoScheduler.h`
+- `FakeGatoScheduler.cpp`
+- `SchedulerBase.cpp`
+- `NavienManager.ino`
+
+**Work:**
+
+*`FakeGatoScheduler.h`:*
+- Add `int _lastKnownUtcOffsetMin = 0;`
+- Add `void convertEveSlotsToUTC(int utcOffsetMin);`
+
+*`FakeGatoScheduler.cpp`:*
+- Remove `timegm()` TZ-swap hack (lines 34–56); replace all callers with `proper_timegm()`.
+- `parseProgramData()` `CURRENT_TIME` case: compute and store `_lastKnownUtcOffsetMin`; clamp to ±720 min; log warning if out of range.
+- `parseProgramData()` `WEEK_SCHEDULE` case: call `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` before `updateSchedulerWeekSchedule()`.
+- Packet ordering mitigation: if `WEEK_SCHEDULE` arrives before `CURRENT_TIME` in the same buffer, recompute offset inline from `prog_send_data.currentTime` vs `time(nullptr)` rather than using the stale member. Note: this is only reliable if `prog_send_data.currentTime` was refreshed in the same or a recent session; a stale value from a prior connection is the same residual risk noted elsewhere in the plan.
+- Implement `convertEveSlotsToUTC()` with day-rollover and midnight-truncation logic.
+- `FakeGatoScheduler::begin()`: add `schedVersion` check on `SAVED_DATA` handle before `updateSchedulerWeekSchedule()`; if version != 1, clear slots and write version 1.
+- All Eve readback paths: convert stored UTC slots → local before sending to Eve.
+- `addMilliseconds()`: add comment — intentionally local-time (Eve wire struct).
+- `guessTimeZone()`: add comment — TZ is now display-only.
+- `updateCurrentScheduleIfNeeded()`: add comment — intentionally `localtime()`.
+
+*`SchedulerBase.cpp`:*
+- `initializeCurrentState()` line 390: `localtime` → `gmtime`.
+- `getNextState()` lines 157, 173: `localtime` → `gmtime`.
+- `getNextState()` lines 194, 217: `tm_isdst = -1` → `0`; `mktime` → `proper_timegm`.
+- `loop()` line 434: remove `getenv("TZ") == 0` guard.
+- `begin()`: update TZ-missing log message to reflect display-only status.
+
+*`NavienManager.ino`:*
+- `loop()` lines 114–121: replace TZ+`getLocalTime()` gate with raw epoch check (`time(nullptr) > 1700000000L`).
+
+**Post-flash steps:**
+1. Verify weblog shows `schedVersion` migration reset message.
+2. Open Eve app → Programs tab → re-save the week schedule (triggers `parseProgramData()` → `convertEveSlotsToUTC()` → NVS write).
+3. Verify telnet `schedule` command shows correct local times (confirms UTC→local display conversion).
+4. Verify Eve shows correct schedule times.
+5. Wait for a scheduled recirc event and confirm it fires at the correct local wall-clock time.
+
+---
+
+### Phase 4 — Python Tools
+**Goal:** Bootstrap and bucket-export scripts generate UTC indices; no local timezone dependency.
+
+**No firmware flash required.** Must be applied before Phase 2's post-flash step 2 — `navien_bucket_export.py --push --replace` must send `schema_version: 2` with UTC-indexed buckets or the device will reject the payload. Can otherwise be applied independently of Phase 3.
+
+**Files:**
+- `Logger/navien_schedule_learner.py`
+- `Logger/navien_bootstrap.py`
+- `Logger/navien_bucket_export.py`
+
+**Work:**
+
+*`navien_schedule_learner.py`:*
+- `_extract_cold_starts()`: remove `local_tz` parameter; keep timestamps as UTC `datetime`.
+- `fetch_consumption_events()`: remove `local_tz` parameter.
+- `events_to_minutes()`: `dow` and `minute_of_day` now derived from UTC `datetime`. Update display strings from local-time labels to UTC.
+- `main()`: remove `detect_local_timezone()` call and timezone print.
+
+*`navien_bootstrap.py`:*
+- Remove `nsl.detect_local_timezone()` call (line 101) and print.
+- Update `nsl.fetch_consumption_events(args, local_tz)` → `nsl.fetch_consumption_events(args)`.
+
+*`navien_bucket_export.py`:*
+- Remove `local_tz` from `build_bucket_payload()` signature (line 36).
+- Remove `nsl.detect_local_timezone()` call (line 175) and print.
+- Update `build_bucket_payload(args, local_tz, ...)` → `build_bucket_payload(args, ...)`.
+- Send `schema_version: 2` in payload.
+
+**Post-run verification:**
+- Dry-run `navien_bootstrap.py` and confirm peak times look correct in UTC (SF morning peaks should appear around 14:00–16:00 UTC).
+- Run `navien_bucket_export.py --push --replace` to re-seed with UTC buckets.
 
 ---
 

--- a/UTC_MIGRATION_PLAN.md
+++ b/UTC_MIGRATION_PLAN.md
@@ -130,19 +130,31 @@ Sign: for PST (UTC-8), sysUTC=15:00 and evePseudo=07:00, so `_lastKnownUtcOffset
 
 **`onNavienState()` (line 171)** — `localtime(&now)` → `gmtime(&now)` for `_runDow` and `_runBucket`.
 
-**`idleStep()` (lines 436–448)** — Replace `localtime_r` midnight detection with 24h elapsed timer:
+**`idleStep()` (lines 436–448)** — Replace `localtime_r` midnight detection with 24h elapsed timer (same `now > 1700000000L` guard as startup decay so bogus pre-NTP epochs are not anchored):
 ```cpp
-if (_lastRecomputeTime24h == 0) _lastRecomputeTime24h = now;
-if (now - _lastRecomputeTime24h >= 86400L) {
-    _lastRecomputeTime24h = now;
-    struct tm tm_buf;
-    struct tm *t = gmtime_r(&now, &tm_buf);
-    if (t->tm_wday == 0)          // UTC Sunday
-        advanceMeasuredWeek();
-    _taskState = DECAY_CHECK;
+time_t now = time(nullptr);
+if (now > 1700000000L) {
+    if (_lastRecomputeTime24h == 0) {
+        // First eligible tick — persist immediately so a reboot within the first
+        // 24h window anchors from this point rather than resetting to zero.
+        _lastRecomputeTime24h = now;
+        saveMeasured();
+    }
+    // Guard NTP backward jump: a forward jump fires one recompute early at most.
+    if (_lastRecomputeTime24h > now) _lastRecomputeTime24h = now;
+    if (now - _lastRecomputeTime24h >= 86400L) {
+        _lastRecomputeTime24h = now;
+        struct tm tm_buf;
+        struct tm *t = gmtime_r(&now, &tm_buf);
+        if (t->tm_wday == 0)
+            advanceMeasuredWeek();  // advanceMeasuredWeek() calls saveMeasured()
+        else
+            saveMeasured();         // persist updated 24h anchor between weekly saves
+        _taskState = DECAY_CHECK;
+    }
 }
 ```
-Remove `_lastRecomputeYday` usage.
+Remove `_lastRecomputeYday` usage. `_lastRecomputeTime24h` is persisted in `MeasuredFile` as `int64_t` (future-safe if `time_t` widens; ESP32 platform limit is 2038 regardless) and restored by `loadMeasured()` on boot.
 
 **`decayCheck()` (line 476)** — `localtime_r` → `gmtime_r`.
 
@@ -244,7 +256,7 @@ if (!timeInit) {
 
 The migration is split into four independently flashable phases. Each phase can be verified before starting the next. Phases 2 and 3 each require a post-flash step; Phase 4 is Python-only and requires no firmware flash.
 
-> **Why this order?** Phase 1 proves `proper_timegm()` before anything depends on it. Phase 2 is self-contained (learner/buckets have no schedule dependency). Phase 3 is the highest-risk change and is tackled last on a proven foundation. Phase 4 must be applied before Phase 2's post-flash step 2 (`navien_bucket_export.py --push --replace`) — the device will reject a `schema_version: 1` payload after `BUCKET_SCHEMA_VERSION` is bumped to 2, and the old script produces local-time bucket indices that would contradict the UTC firmware.
+> **Why this order?** Phase 1 proves `proper_timegm()` before anything depends on it. Phase 2 makes learner/buckets UTC-native and gates the learner→scheduler apply path so UTC-indexed slots cannot reach the still-local-time firing path; schedule behavior is unchanged. Phase 3 is the highest-risk change and is tackled last on a proven foundation. Phase 4 must be applied before Phase 2's post-flash step 3 (`navien_bucket_export.py --push --replace`) — the device will reject a `schema_version: 1` payload after `BUCKET_SCHEMA_VERSION` is bumped to 2, and the old script produces local-time bucket indices that would contradict the UTC firmware.
 
 ---
 
@@ -265,30 +277,36 @@ The migration is split into four independently flashable phases. Each phase can 
 ---
 
 ### Phase 2 — Learner & Buckets
-**Goal:** Bucket recording and daily recompute become UTC-based. Completely independent of the schedule system.
+**Goal:** Bucket recording and daily recompute become UTC-based. Schedule firing is unchanged: the learner→scheduler apply path is gated behind `_scheduleIsUtc` (set false until Phase 3) so UTC-indexed learner output cannot reach the still-local-time firing path.
 
 **Files:**
 - `NavienLearner.cpp`
 - `NavienLearner.h`
 - `BucketStore.cpp`
 - `BucketStore.h`
+- `FakeGatoScheduler.h` *(add `_scheduleIsUtc = false` gate)*
+- `FakeGatoScheduler.cpp` *(guard learner handoff on `_scheduleIsUtc`)*
 
 **Work:**
 - `onNavienState()` line 171: `localtime` → `gmtime` for `_runDow` and `_runBucket`.
-- `idleStep()` lines 436–448: replace `localtime_r` midnight detection with 24h elapsed timer; UTC Sunday check for `advanceMeasuredWeek()`.
+- `idleStep()` lines 436–448: replace `localtime_r` midnight detection with 24h elapsed timer; gate the whole block on `now > 1700000000L` (plausible NTP-synced epoch); UTC Sunday check for `advanceMeasuredWeek()`.
 - `decayCheck()` line 476: `localtime_r` → `gmtime_r`.
 - `ingestBucketPayload()` line 656: `localtime` → `gmtime`.
 - `BucketStore::begin()` line 67: `localtime` → `gmtime`.
 - Bump `BUCKET_SCHEMA_VERSION` to 2 (forces `initEmpty()` on first boot).
 - Bump `MEASURED_SCHEMA_VERSION` to 2 (clean reset; 4-week window repopulates within a week).
 - Replace `_lastRecomputeYday` with `_lastRecomputeTime24h` in `NavienLearner.h` and constructor.
+- Add `int64_t last_recompute_24h` to `MeasuredFile`; persist in `saveMeasured()`, restore in `loadMeasured()`.
+- Call `saveMeasured()` whenever the 24h branch fires (non-Sunday path); `advanceMeasuredWeek()` already calls it on Sunday.
+- Add `_scheduleIsUtc = false` and `setScheduleUtcMode(bool)` to `FakeGatoScheduler`; gate learner→`setWeekScheduleFromJSON` handoff on `_scheduleIsUtc` in `loop()`. A `// TODO(Phase 3)` comment in `begin()` marks where to call `setScheduleUtcMode(true)` after the `schedVersion` migration check.
 
-> **Mixed-state note:** Between flashing Phase 2 and Phase 3, buckets are UTC-indexed while schedule firing remains local-time. The two are internally consistent within their own subsystems, but bucket timestamps and slot boundaries will not align until Phase 3 is flashed. This is expected and harmless for the interim period.
+> **Mixed-state note:** Between flashing Phase 2 and Phase 3, buckets are UTC-indexed while schedule firing remains local-time. The learner→scheduler auto-apply path (`FakeGatoScheduler::loop()` → `setWeekScheduleFromJSON()`) is **suppressed** until Phase 3 sets `_scheduleIsUtc = true` — learner recomputes run and produce UTC slots, but those slots are not applied to the firing path until the scheduler is also UTC-aware. This prevents UTC-indexed learner output from being interpreted as local-time and firing at the wrong wall-clock time.
 
 **Post-flash steps:**
 1. Verify device boots and weblog shows bucket schema reset.
-2. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
-3. Monitor for 24–48 hours: confirm recompute fires roughly 24h after startup (not at wrong local hour). Note: the first interval is 24h from the first eligible `idleStep()` tick with a valid `now`, not from NTP sync itself — in practice the same order of magnitude but not exact.
+2. **Prerequisite: Phase 4 must be applied first.** `navien_bucket_export.py` must send `schema_version: 2` with UTC-indexed buckets. The pre-Phase-4 script sends local-time indices and `schema_version: 1`, which the device will reject (schema mismatch). Apply Phase 4 Python changes before running this step.
+3. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
+4. Monitor for 24–48 hours: confirm recompute fires roughly 24h after startup (not at wrong local hour). Note: `_lastRecomputeTime24h` is persisted to `measured.bin` whenever the 24h branch fires (and on every `advanceMeasuredWeek()` / OTA / `saveLearner`), so the anchor survives reboots and the first post-reboot interval is at most 24h from the last persisted value.
 
 ---
 
@@ -316,7 +334,7 @@ The migration is split into four independently flashable phases. Each phase can 
 - `parseProgramData()` `WEEK_SCHEDULE` case: call `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` before `updateSchedulerWeekSchedule()`.
 - Packet ordering mitigation: if `WEEK_SCHEDULE` arrives before `CURRENT_TIME` in the same buffer, recompute offset inline from `prog_send_data.currentTime` vs `time(nullptr)` rather than using the stale member. Note: this is only reliable if `prog_send_data.currentTime` was refreshed in the same or a recent session; a stale value from a prior connection is the same residual risk noted elsewhere in the plan.
 - Implement `convertEveSlotsToUTC()` with day-rollover and midnight-truncation logic.
-- `FakeGatoScheduler::begin()`: add `schedVersion` check on `SAVED_DATA` handle before `updateSchedulerWeekSchedule()`; if version != 1, clear slots and write version 1.
+- `FakeGatoScheduler::begin()`: add `schedVersion` check on `SAVED_DATA` handle before `updateSchedulerWeekSchedule()`; if version != 1, clear slots and write version 1. After confirming slots are UTC-valid, call `setScheduleUtcMode(true)` to enable the learner→scheduler handoff (replaces the `// TODO(Phase 3)` stub from Phase 2).
 - All Eve readback paths: convert stored UTC slots → local before sending to Eve.
 - `addMilliseconds()`: add comment — intentionally local-time (Eve wire struct).
 - `guessTimeZone()`: add comment — TZ is now display-only.
@@ -344,7 +362,7 @@ The migration is split into four independently flashable phases. Each phase can 
 ### Phase 4 — Python Tools
 **Goal:** Bootstrap and bucket-export scripts generate UTC indices; no local timezone dependency.
 
-**No firmware flash required.** Must be applied before Phase 2's post-flash step 2 — `navien_bucket_export.py --push --replace` must send `schema_version: 2` with UTC-indexed buckets or the device will reject the payload. Can otherwise be applied independently of Phase 3.
+**No firmware flash required.** Must be applied before Phase 2's post-flash step 3 — `navien_bucket_export.py --push --replace` must send `schema_version: 2` with UTC-indexed buckets or the device will reject the payload. Can otherwise be applied independently of Phase 3.
 
 **Files:**
 - `Logger/navien_schedule_learner.py`

--- a/UTC_MIGRATION_PLAN.md
+++ b/UTC_MIGRATION_PLAN.md
@@ -326,16 +326,22 @@ The migration is split into four independently flashable phases. Each phase can 
 
 *`FakeGatoScheduler.h`:*
 - Add `int _lastKnownUtcOffsetMin = 0;`
+- Add `bool _utcOffsetKnown = false;`
 - Add `void convertEveSlotsToUTC(int utcOffsetMin);`
+- Add `int getEffectiveOffsetMin() const;`
+- Add `void sanitizeScheduleToLocalLimit(int offsetMin);`
 
 *`FakeGatoScheduler.cpp`:*
 - Remove `timegm()` TZ-swap hack (lines 34–56); replace all callers with `proper_timegm()`.
-- `parseProgramData()` `CURRENT_TIME` case: compute and store `_lastKnownUtcOffsetMin`; clamp to ±720 min; log warning if out of range.
-- `parseProgramData()` `WEEK_SCHEDULE` case: call `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` before `updateSchedulerWeekSchedule()`.
+- `parseProgramData()` `CURRENT_TIME` case: compute and store `_lastKnownUtcOffsetMin`; set `_utcOffsetKnown = true`; clamp to ±720 min; log warning if out of range.
+- `parseProgramData()` `WEEK_SCHEDULE` case: call `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` before `updateSchedulerWeekSchedule()`. If `_utcOffsetKnown` is false, discard the received schedule and log a warning — Eve will re-send after a `CURRENT_TIME` packet establishes the offset.
 - Packet ordering mitigation: if `WEEK_SCHEDULE` arrives before `CURRENT_TIME` in the same buffer, recompute offset inline from `prog_send_data.currentTime` vs `time(nullptr)` rather than using the stale member. Note: this is only reliable if `prog_send_data.currentTime` was refreshed in the same or a recent session; a stale value from a prior connection is the same residual risk noted elsewhere in the plan.
-- Implement `convertEveSlotsToUTC()` with day-rollover and midnight-truncation logic.
+- Implement `convertEveSlotsToUTC()` with day-rollover and midnight-truncation logic. Calls `sanitizeScheduleToLocalLimit()` after converting.
+- Add `getEffectiveOffsetMin()` helper: returns `_lastKnownUtcOffsetMin` if `_utcOffsetKnown`, otherwise derives the offset from `localtime_r` / `gmtime_r` on the current epoch (system TZ fallback). Returns `INT_MIN` if neither is available.
+- Add `sanitizeScheduleToLocalLimit(int offsetMin)`: round-trips `prog_send_data.weekSchedule` through UTC→local→UTC via `convertSlotsOffset`. Any UTC slot whose local-time projection would exceed the 3-slot Eve UI limit on its local day is dropped from storage, preventing it from firing silently. **Called only from `convertEveSlotsToUTC()` (the Eve→device path). Never called from `setWeekScheduleFromJSON()`.** See post-implementation note below.
+- `convertSlotsOffset()`: enforce 3-slot cap per output day (Eve UI limit is 3, not 4); round slot offsets to nearest 10-minute boundary (`(val + 5) / 10`) instead of truncating to avoid 1-minute jitter in `_lastKnownUtcOffsetMin` shifting a slot to the wrong 10-minute bucket.
 - `FakeGatoScheduler::begin()`: add `schedVersion` check on `SAVED_DATA` handle before `updateSchedulerWeekSchedule()`; if version != 1, clear slots and write version 1. After confirming slots are UTC-valid, call `setScheduleUtcMode(true)` to enable the learner→scheduler handoff (replaces the `// TODO(Phase 3)` stub from Phase 2).
-- All Eve readback paths: convert stored UTC slots → local before sending to Eve.
+- `loop()` Eve readback: use `getEffectiveOffsetMin()` instead of `_lastKnownUtcOffsetMin` directly. This ensures the device sends correct local-time slots to Eve on first boot before any `CURRENT_TIME` packet has established `_lastKnownUtcOffsetMin` — without the fallback, `_lastKnownUtcOffsetMin` defaults to 0 and Eve receives raw UTC times, which it then double-converts on the next write-back.
 - `addMilliseconds()`: add comment — intentionally local-time (Eve wire struct).
 - `guessTimeZone()`: add comment — TZ is now display-only.
 - `updateCurrentScheduleIfNeeded()`: add comment — intentionally `localtime()`.
@@ -353,9 +359,25 @@ The migration is split into four independently flashable phases. Each phase can 
 **Post-flash steps:**
 1. Verify weblog shows `schedVersion` migration reset message.
 2. Open Eve app → Programs tab → re-save the week schedule (triggers `parseProgramData()` → `convertEveSlotsToUTC()` → NVS write).
-3. Verify telnet `schedule` command shows correct local times (confirms UTC→local display conversion).
+3. Verify telnet `schedule` command shows correct local times with UTC annotation (confirms UTC→local display conversion).
 4. Verify Eve shows correct schedule times.
 5. Wait for a scheduled recirc event and confirm it fires at the correct local wall-clock time.
+
+**Post-Phase-3 additions (not in original plan):**
+
+*Telnet `scheduler` command enhancements (`TelnetCommands.cpp`):*
+- Slots are now displayed as both local time and UTC: `HH:MM-HH:MM (UTC HH:MM-HH:MM)`.
+- When a UTC slot's local time falls on the previous calendar day (e.g. Monday UTC 04:00 = Sunday local 21:00 in PDT), the display appends `prev day` to the UTC annotation. Slots are sorted by local start time for readability.
+
+*Bug fix — `setWeekScheduleFromJSON()` incorrectly called `sanitizeScheduleToLocalLimit()`:*
+
+When `navien_bucket_export.py --push` pushes a JSON schedule, slots are already in UTC with ≤3 per UTC day. The sanitize round-trip (UTC→local→UTC via `convertSlotsOffset`) was nevertheless applied, and it dropped valid same-day UTC slots. The failure mode:
+
+`convertSlotsOffset` iterates Eve days 0→6. A cross-day UTC slot from day N that rolls back into local day N-1 is processed *before* day N-1's own native slots. It fills one of the three available slot positions on local day N-1. When day N-1's native UTC slots are subsequently processed, the 3-slot cap is hit one slot early and the last native slot is silently dropped.
+
+Example: Monday UTC 04:00 → Sunday local 21:00 (PDT). This steals `slot[0]` of Sunday's local view. Sunday's own UTC slots 13:50, 16:40, 18:00 then fill `slot[1]`, `slot[2]`, and attempt `slot[3]` — which is capped. Sunday UTC 18:00-19:00 is dropped from storage and never fires.
+
+**Fix:** `sanitizeScheduleToLocalLimit()` is called only from `convertEveSlotsToUTC()` (the Eve→device path, where Eve sends local-time slots that genuinely require sanitization after UTC conversion). It is never called from `setWeekScheduleFromJSON()`. JSON-pushed UTC schedules need no sanitization: they are already within the 3-slot-per-UTC-day limit, and the Monday 04:00 UTC slot is fully visible in Eve (displayed as 21:00 on Monday's tab in local time) — the cross-day mapping is display-only, not a storage problem.
 
 ---
 
@@ -403,3 +425,5 @@ Add to Architecture notes:
 - TZ is stored in NVS for display only. A wrong TZ (e.g. from a remote Eve connection) corrupts the Eve schedule display but cannot cause schedules to fire at the wrong time.
 - The nightly recompute fires on a 24h elapsed timer (`_lastRecomputeTime24h`), not localtime midnight detection.
 - `proper_timegm()` is the TZ-free `timegm()` equivalent. Use it whenever a UTC `struct tm` must be converted to `time_t`.
+- `getEffectiveOffsetMin()` is the authoritative source for the UTC↔local offset. It prefers the Eve-confirmed `_lastKnownUtcOffsetMin` (set when Eve sends a `CURRENT_TIME` packet), falling back to the system TZ derived from `localtime_r`/`gmtime_r`. Use it anywhere the UTC offset is needed rather than reading `_lastKnownUtcOffsetMin` directly.
+- `sanitizeScheduleToLocalLimit()` is called only from `convertEveSlotsToUTC()` (Eve→device path). Never call it on JSON-pushed schedules: the round-trip incorrectly drops native same-day UTC slots when cross-day slots from adjacent UTC days fill their slot positions first.

--- a/UTC_MIGRATION_PLAN.md
+++ b/UTC_MIGRATION_PLAN.md
@@ -1,0 +1,274 @@
+# UTC Migration Plan: NavienManager Timezone-Independence
+
+## Goal
+
+Make NavienManager timezone-independent at runtime. Currently `localtime()` is used throughout, making the system vulnerable to `guessTimeZone()` writing a wrong TZ when an Eve/HomeKit app connects from a remote timezone (e.g. Hawaii overwrites SF timezone, breaking schedule firing and bucket recording for the duration).
+
+## Target State
+
+| Concern | Before | After |
+|---|---|---|
+| Schedule slots stored | Local hour:min | UTC hour:min |
+| Schedule fire comparison | `localtime()` vs local slot | `gmtime()` vs UTC slot |
+| Bucket index | `localtime()` hour:min | `gmtime()` hour:min |
+| Midnight recompute | local `tm_hour==0` detection | 24h elapsed timer |
+| TZ in NVS | Runtime-critical | Display-only |
+| Wrong TZ consequence | Fires at wrong time | Shows wrong time to user only |
+
+## Impact
+
+- A wrong `guessTimeZone()` (remote Eve connection) corrupts only the display of schedule times on the Eve app and webpage — it cannot cause schedules to fire at the wrong time.
+- Bucket data will be invalidated by the firmware change and must be re-seeded via `navien_bucket_export.py --push --replace` after flashing.
+- After flashing, the user must re-push the schedule once from the Eve app (or via `navien_bootstrap.py --push`) to re-populate NVS with UTC-converted slots.
+
+---
+
+## New Files
+
+### `TimeUtils.h` / `TimeUtils.cpp`
+
+A TZ-free `timegm()` equivalent. The current `timegm()` hack in `FakeGatoScheduler.cpp` temporarily sets `TZ=UTC0` via `setenv`, which is not reentrant and corrupts state if interrupted. Replace with arithmetic:
+
+```cpp
+// TimeUtils.h
+#pragma once
+#include <time.h>
+time_t proper_timegm(const struct tm *t);
+
+// TimeUtils.cpp
+time_t proper_timegm(const struct tm *t) {
+    int y = t->tm_year + 1900, m = t->tm_mon + 1;
+    if (m <= 2) { y--; m += 12; }
+    long days = (long)(365 * y) + (y/4) - (y/100) + (y/400)
+              + (long)(30.6001 * (m + 1)) + t->tm_mday - 719591L;
+    return (time_t)(days * 86400L + t->tm_hour * 3600L + t->tm_min * 60L + t->tm_sec);
+}
+```
+
+Use a **unit-tested** calendar→epoch implementation (integer mudane / Fliegel–Van Flandern style is preferable to `30.6001` floating‑point) and validate against known `struct tm` ↔ UTC instants on the ESP32 toolchain; `time_t` is signed 32‑bit on many Arduino builds, so document the supported year range.
+
+Include from `SchedulerBase.cpp` and `FakeGatoScheduler.cpp`.
+
+---
+
+## Firmware Changes
+
+### `FakeGatoScheduler.h`
+
+- Add private member `int _lastKnownUtcOffsetMin = 0;`
+- Add private method `void convertEveSlotsToUTC(int utcOffsetMin);`
+
+### `FakeGatoScheduler.cpp`
+
+**`timegm()` (lines 34–56)** — Remove entirely. Replace all callers with `proper_timegm()` from `TimeUtils.h`.
+
+**`addMilliseconds()` (lines 177–202)** — Uses `mktime()` / `localtime()` on Eve's wire-format time struct. This struct is display-only (sent back to Eve). Keep as-is; add comment: `// Eve wire time — intentionally local-time`.
+
+**`guessTimeZone()` (lines 204–238)** — No structural change. TZ is still stored in NVS for display. Add comment: `// TZ is now display-only; wrong TZ corrupts Eve display but not schedule firing.`
+
+**`parseProgramData()` — `CURRENT_TIME` case (line 429)** — After copying `currentTime` into `prog_send_data`, compute and store the UTC offset:
+```cpp
+struct tm eveUTC = {0};
+eveUTC.tm_year = currentTime->year + 100;
+eveUTC.tm_mon  = currentTime->month - 1;
+eveUTC.tm_mday = currentTime->day;
+eveUTC.tm_hour = currentTime->hours;
+eveUTC.tm_min  = currentTime->minutes;
+time_t evePseudo = proper_timegm(&eveUTC);   // treat Eve local as UTC
+time_t sysUTC    = time(nullptr);
+_lastKnownUtcOffsetMin = (int)(difftime(sysUTC, evePseudo) / 60.0 + 0.5);
+```
+Sign: for PST (UTC-8), sysUTC=15:00 and evePseudo=07:00, so `_lastKnownUtcOffsetMin = +480`. UTC = local + offset.
+
+**`parseProgramData()` — `WEEK_SCHEDULE` case (line 411)** — After copying Eve's schedule, call `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` before `updateSchedulerWeekSchedule()`.
+
+**Packet ordering** — `_lastKnownUtcOffsetMin` is updated in the `CURRENT_TIME` case. If a single `parseProgramData()` buffer can deliver `WEEK_SCHEDULE` before `CURRENT_TIME`, offset may still be stale for that parse pass. Mitigations: (a) process TLVs in an order that applies offset before conversion when both appear in one buffer, or (b) if offset is unknown, defer conversion until after the full buffer is parsed, or (c) on `WEEK_SCHEDULE` only, recompute offset from `guessTimeZone()`’s existing `timegm`/pseudo-UTC vs `time(nullptr)` logic so a lone week packet still converts.
+
+**New `convertEveSlotsToUTC(int utcOffsetMin)`** — Converts `prog_send_data.weekSchedule` slots in-place from Eve local-time to UTC. Algorithm:
+1. Snapshot the current `prog_send_data.weekSchedule`; zero-fill a fresh copy.
+2. For each Eve day `d` (0=Mon..6=Sun), for each slot where `offset_start != 0xFF`:
+   - `local_start = slot.offset_start * 10` (minutes since local midnight)
+   - `local_end   = slot.offset_end   * 10`
+   - `utc_start   = local_start + utcOffsetMin`
+   - `utc_end     = local_end   + utcOffsetMin`
+   - Map to SchedulerBase day: `sb_day = (d + 1) % 7`
+   - If `utc_start < 0` or `utc_start >= 1440`, adjust `sb_day` by ±1 and normalise minutes.
+   - Slot straddles UTC midnight (start and end in different days): truncate at 23:50/00:00 and log a warning.
+   - Round to nearest 10-minute boundary; write into first free slot of target day.
+3. Overwrite `prog_send_data.weekSchedule` with the UTC-converted copy.
+
+**`updateCurrentScheduleIfNeeded()` (line 474)** — Keeps `localtime()`. This selects which day's schedule to show in the Eve app (display). Add comment: `// Intentionally localtime — selects which local day to show Eve.`
+
+**`stateChange()` log print (line 122)** — Uses `localtime()` for the "Next event scheduled for:" message. Keep as-is; display only.
+
+### `SchedulerBase.cpp`
+
+**`begin()` (lines 319–373)** — Update the log line that says schedules will not run until TZ is set; after migration, TZ is optional for firing (still used for display).
+
+**Schedule migration must not live only here** — `FakeGatoScheduler` overrides `loadScheduleFromStorage()` / `saveScheduleToStorage()` to no-ops and treats **`prog_send_data` in NVS namespace `SAVED_DATA`** as the source of truth. `FakeGatoScheduler::begin()` then calls `updateSchedulerWeekSchedule()`, which copies `prog_send_data.weekSchedule` into in-RAM `weekSchedule[]`. Any `initDefault()` + `saveScheduleToStorage()` sequence in `SchedulerBase::begin()` therefore does **not** persist through boot: the stubbed save is a no-op, and the child `begin()` immediately reapplies the old blob. The UTC migration reset (version key + cleared or default schedule + NVS commit) must run in **`FakeGatoScheduler`’s constructor or `begin()`**, on the **`savedData` (`SAVED_DATA`)** handle, **before** the final `updateSchedulerWeekSchedule()` that applies `prog_send_data` to `weekSchedule[]`.
+
+**`loop()` TZ guard (line 434)** — Remove `if (getenv("TZ") == 0) { isInitialized = false; return; }`. TZ is no longer required for firing.
+
+**`initializeCurrentState()` (line 390)** — `localtime(&now)` → `gmtime(&now)`.
+
+**`getNextState()` (lines 157, 173, 188, 195, 213, 218):**
+- Line 157: `localtime(&endVacationTime)` → `gmtime(&endVacationTime)`
+- Line 173: `localtime(&now)` → `gmtime(&now)`
+- Lines 194 & 217: `tm_isdst = -1` → `tm_isdst = 0`
+- Lines 195 & 218: `mktime(&nextState_tm)` → `proper_timegm(&nextState_tm)`
+
+### `NavienLearner.h`
+
+- Replace `int _lastRecomputeYday` with `time_t _lastRecomputeTime24h`.
+- Update constructor initialiser: `_lastRecomputeYday(-1)` → `_lastRecomputeTime24h(0)`.
+
+### `NavienLearner.cpp`
+
+**`onNavienState()` (line 171)** — `localtime(&now)` → `gmtime(&now)` for `_runDow` and `_runBucket`.
+
+**`idleStep()` (lines 436–448)** — Replace `localtime_r` midnight detection with 24h elapsed timer:
+```cpp
+if (_lastRecomputeTime24h == 0) _lastRecomputeTime24h = now;
+if (now - _lastRecomputeTime24h >= 86400L) {
+    _lastRecomputeTime24h = now;
+    struct tm tm_buf;
+    struct tm *t = gmtime_r(&now, &tm_buf);
+    if (t->tm_wday == 0)          // UTC Sunday
+        advanceMeasuredWeek();
+    _taskState = DECAY_CHECK;
+}
+```
+Remove `_lastRecomputeYday` usage.
+
+**`decayCheck()` (line 476)** — `localtime_r` → `gmtime_r`.
+
+**`ingestBucketPayload()` (line 656)** — `localtime` → `gmtime`.
+
+**`appendStatusHTML()` (line 784)** — Keep `localtime_r`; display only. Add comment.
+
+### `BucketStore.cpp`
+
+**`begin()` (line 67)** — `localtime(&now)` → `gmtime`. Year is TZ-independent for any reasonable offset, but consistency with `decayCheck()` requires both use the same reference.
+
+Also bump `BUCKET_SCHEMA_VERSION` (in `BucketStore.h`) from 1 to 2 to force a clean reset of `buckets.bin` on first boot after firmware flash.
+
+### `NavienManager.ino`
+
+**`loop()` (lines 114–121)** — Replace TZ+`getLocalTime()` gate with epoch check:
+```cpp
+if (!timeInit) {
+    if (time(nullptr) > 1700000000L) {
+        timeInit = true;
+        homeSpan.assumeTimeAcquired();
+    }
+}
+```
+
+---
+
+## What Stays Local-Time (Display Only)
+
+| Location | Data | Reason |
+|---|---|---|
+| `addMilliseconds()` / `prog_send_data.currentTime` | Eve wire time struct | Sent back to Eve for display |
+| `updateCurrentScheduleIfNeeded()` | Day-of-week selection | Which local day Eve shows |
+| `stateChange()` log message | Next event timestamp | Human-readable serial |
+| `appendStatusHTML()` | Last recompute timestamp | Webpage display |
+| `TelnetCommands.cpp` (all) | All time displays | Human-readable output |
+| `guessTimeZone()` / NVS TZ | TZ string | Convert stored UTC slots → local for Eve readback |
+| `HomeSpanWeb.ino` | Status strings | Display-only local labels (optional later: UTC labels or explicit “local”) |
+
+---
+
+## NVS / Storage Migration
+
+| Store | Key | Change |
+|---|---|---|
+| NVS `SAVED_DATA` / `PROG_SEND_DATA` (`prog_send_data`, includes `weekSchedule`) | Existing local-time Eve slots | Reset or clear on boot if `schedVersion != 1` (see **FakeGatoScheduler** above); re-push from Eve or Python required |
+| NVS `SAVED_DATA` / `schedVersion` (new) | `uint8_t` | Prefer this namespace so it ships with the blob the firmware actually reloads; set to `1` after migration reset |
+| NVS `SCHEDULER` / `weekSchedule` | Legacy blob | `FakeGatoScheduler` does not load/save this path today; optional cleanup or bump for hygiene, but **not sufficient alone** for migration |
+| `/navien/buckets.bin` | `BUCKET_SCHEMA_VERSION` bump to 2 | Forces `initEmpty()` on first boot; re-seed via `navien_bucket_export.py --push --replace` |
+| `/navien/measured.bin` | `MEASURED_SCHEMA_VERSION` bump to 2 | Clean reset; 4-week window repopulates within a week |
+
+---
+
+## Python Changes
+
+### `navien_schedule_learner.py`
+
+**`_extract_cold_starts()` / `fetch_consumption_events()`:**
+- Remove `local_tz` parameter.
+- Remove `dt_utc.astimezone(local_tz)` conversion; keep timestamps as UTC `datetime`.
+- `dow` and `minute_of_day` now derived from UTC datetime.
+
+**`events_to_minutes()`:**
+- `dt` is now UTC. `minute_of_day = dt.hour * 60 + dt.minute` gives UTC minute. Correct for UTC buckets.
+
+**`main()`:**
+- Remove `local_tz, tz_name = detect_local_timezone()` and the timezone print.
+- Update `fetch_consumption_events(args, local_tz)` → `fetch_consumption_events(args)`.
+- Update display strings from local-time labels to UTC.
+
+**`POST /schedule` output** — `buckets_to_windows()` result is now UTC-minute-indexed; `week` JSON contains UTC hours/minutes. No schema change; `setWeekScheduleFromJSON()` on the firmware stores verbatim (already UTC).
+
+### `navien_bootstrap.py`
+
+- Remove `local_tz, tz_name = nsl.detect_local_timezone()` (line 101) and print.
+- Update `nsl.fetch_consumption_events(args, local_tz)` → `nsl.fetch_consumption_events(args)`.
+
+### `navien_bucket_export.py`
+
+- Remove `local_tz` from `build_bucket_payload()` signature (line 36).
+- Remove `nsl.detect_local_timezone()` call (line 175) and print.
+- Update `build_bucket_payload(args, local_tz, ...)` → `build_bucket_payload(args, ...)`.
+- Send `schema_version: 2` in the payload to match the bumped `BUCKET_SCHEMA_VERSION`.
+
+---
+
+## Protocol Change Summary
+
+| Endpoint | Before | After |
+|---|---|---|
+| `POST /schedule` (Python) | local-time hour:min | UTC hour:min (no schema change) |
+| `POST /buckets` (Python) | local-time dow/bucket | UTC dow/bucket; `schema_version: 2` |
+| Eve BLE `WEEK_SCHEDULE` write | local-time → stored local | local-time → converted to UTC → stored UTC |
+| Eve BLE schedule read | stored local returned verbatim | stored UTC → converted to local → returned (requires explicit encode path in firmware wherever `ProgramData` is assembled for readback — verify all read paths) |
+
+---
+
+## Recommended Implementation Order
+
+1. Create `TimeUtils.h` / `TimeUtils.cpp` with `proper_timegm()`
+2. `FakeGatoScheduler.cpp` — replace `timegm()` hack; add `_lastKnownUtcOffsetMin`; add `convertEveSlotsToUTC()`; wire into `parseProgramData()`; NVS `schedVersion` + migration reset on `SAVED_DATA` before `updateSchedulerWeekSchedule()` in `begin()`; Eve readback UTC→local
+3. `SchedulerBase.cpp` — `gmtime()` + `proper_timegm()` in firing path; remove TZ guard; relax TZ-missing messaging in `begin()`
+4. `NavienLearner.cpp` / `NavienLearner.h` — `gmtime()` for buckets; 24h elapsed timer
+5. `BucketStore.cpp` / `BucketStore.h` — `gmtime()` for year; bump `BUCKET_SCHEMA_VERSION`
+6. `NavienManager.ino` — epoch-based clock gate
+7. Python: `navien_schedule_learner.py` — UTC bucket path; drop `local_tz`
+8. Python: `navien_bootstrap.py` + `navien_bucket_export.py` — drop `local_tz`; send `schema_version: 2`
+
+---
+
+## Post-Flash Checklist
+
+After flashing new firmware:
+1. Verify device boots and connects to WiFi/NTP normally.
+2. Check weblog for the migration reset message (logged from `FakeGatoScheduler` / `SAVED_DATA` path) — confirms slot reset.
+3. Open Eve app → Programs tab → re-save the week schedule (triggers `parseProgramData()` → `convertEveSlotsToUTC()` → NVS write).
+4. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
+5. Run `python3 navien_bootstrap.py --push` if you want the computed schedule re-derived from InfluxDB in UTC.
+6. Verify telnet `schedule` command shows correct local times (confirms UTC→local display conversion).
+7. Verify Eve shows correct schedule times.
+
+---
+
+## CLAUDE.md Additions (after implementation)
+
+Add to Architecture notes:
+
+**UTC-native internal storage**
+- `SchedulerBase::weekSchedule[]` stores UTC hour:minute. `getNextState()` and `initializeCurrentState()` use `gmtime()` and `proper_timegm()` (from `TimeUtils.h`).
+- `NavienLearner` cold-start bucket assignment uses `gmtime()`. `buckets.bin` dow/bucket indices are UTC.
+- TZ is stored in NVS for display only. A wrong TZ (e.g. from a remote Eve connection) corrupts the Eve schedule display but cannot cause schedules to fire at the wrong time.
+- The nightly recompute fires on a 24h elapsed timer (`_lastRecomputeTime24h`), not localtime midnight detection.
+- `proper_timegm()` is the TZ-free `timegm()` equivalent. Use it whenever a UTC `struct tm` must be converted to `time_t`.


### PR DESCRIPTION
# Branch: Remove-timezone-dependence — Merge Description

## Problem

`localtime()` was used throughout the firmware for schedule firing, bucket recording, and midnight recompute triggering. The Eve app's `guessTimeZone()` writes a TZ string to NVS whenever any Eve client connects. A remote Eve connection (e.g., from Hawaii while the device is in San Francisco) overwrites the stored TZ, causing schedules to fire at the wrong wall-clock time and bucket data to be recorded into the wrong day/slot for the duration of the bad TZ.

## Solution

Make all runtime-critical time comparisons UTC-native. TZ is now stored for display only — a wrong TZ corrupts the Eve schedule display but cannot cause schedules to fire at the wrong time or bucket data to land in the wrong slot.

## Changes by Phase

### Phase 1 — Foundation (`TimeUtils.h` / `TimeUtils.cpp`)

Added `proper_timegm()`: a TZ-free, reentrant `timegm()` using integer-arithmetic calendar→epoch conversion. Replaces the previous hack that temporarily set `TZ=UTC0` via `setenv` (not reentrant; corrupts state if interrupted). A host-side test harness (`TimeUtils_test.cpp`) validates epoch=0, 2025-01-01 00:00 UTC, PST/PDT crossover, UTC+9:30 half-hour zone, and the year-2038 boundary.

### Phase 2 — Learner & Buckets

- `NavienLearner::onNavienState()`: `localtime` → `gmtime` for `_runDow` and `_runBucket`. Bucket dow/bucket indices are now UTC.
- `NavienLearner::idleStep()`: replaced `localtime_r` midnight detection with a 24-hour elapsed timer (`_lastRecomputeTime24h`), gated on `now > 1700000000L` to ignore bogus pre-NTP epochs. The anchor is persisted to `measured.bin` so it survives reboots.
- `NavienLearner::decayCheck()` / `ingestBucketPayload()`: `localtime_r` → `gmtime_r`.
- `BucketStore::begin()`: `localtime` → `gmtime`.
- `BUCKET_SCHEMA_VERSION` bumped to 2; `MEASURED_SCHEMA_VERSION` bumped to 2. Both force a clean reset on first boot after flashing.
- Added `_scheduleIsUtc` gate in `FakeGatoScheduler` so UTC-indexed learner output cannot reach the still-local-time firing path until Phase 3 is applied.

### Phase 3 — Schedule System

- `FakeGatoScheduler`: removed the `setenv`-based `timegm()` hack; all callers now use `proper_timegm()`.
- Eve write path (`parseProgramData` / `WEEK_SCHEDULE`): `convertEveSlotsToUTC(_lastKnownUtcOffsetMin)` converts local-time Eve slots to UTC before storage. If `_utcOffsetKnown` is false when `WEEK_SCHEDULE` arrives, the packet is discarded (Eve resends after `CURRENT_TIME` establishes the offset).
- Eve read path (`loop()`): `getEffectiveOffsetMin()` converts stored UTC slots back to local time before sending to Eve. This prevents Eve from double-converting on the next write-back.
- `getEffectiveOffsetMin()`: prefers `_lastKnownUtcOffsetMin` (set from Eve's `CURRENT_TIME` packet); falls back to system TZ derived from `localtime_r`/`gmtime_r`.
- `sanitizeScheduleToLocalLimit()`: called only from `convertEveSlotsToUTC()` (Eve→device path). **Never** called from `setWeekScheduleFromJSON()` (JSON push path already UTC).
- `SchedulerBase`: `getNextState()` and `initializeCurrentState()` use `gmtime()` and `proper_timegm()`; removed `getenv("TZ") == 0` guard from `loop()`; updated TZ-missing log message.
- `NavienManager.ino`: replaced TZ+`getLocalTime()` gate with raw epoch check (`time(nullptr) > 1700000000L`).
- NVS `schedVersion` key added to `SAVED_DATA` namespace; checked in `FakeGatoScheduler::begin()` before applying `prog_send_data` to `weekSchedule[]`. Version != 1 clears slots and writes version 1; user must re-push schedule from Eve or Python after first boot.
- `setScheduleUtcMode(true)` called in `begin()` after migration check, enabling the learner→scheduler handoff suppressed during Phase 2.

### Phase 3 Bug Fix — `setWeekScheduleFromJSON()` slot-drop

`sanitizeScheduleToLocalLimit()` was incorrectly called from `setWeekScheduleFromJSON()`. The round-trip (UTC→local→UTC via `convertSlotsOffset`) iterated Eve days 0→6; a cross-day UTC slot from day N that rolled back into local day N-1 consumed one of the three available slot positions on local day N-1 before that day's own native UTC slots were processed, causing the last native slot to be silently dropped.

Example: Monday UTC 04:00 → Sunday local 21:00 (PDT) stole `slot[0]` of Sunday's local view. Sunday's UTC slots 13:50, 16:40, 18:00 filled `slot[1]`, `slot[2]`, and hit the 3-slot cap — Sunday UTC 18:00-19:00 was dropped and never fired.

Fix: `sanitizeScheduleToLocalLimit()` is now called only from `convertEveSlotsToUTC()`.

### Phase 3 Telnet Enhancement — `TelnetCommands.cpp`

The `scheduler` command now displays each slot as both local time and UTC: `HH:MM-HH:MM (UTC HH:MM-HH:MM)`. When the UTC day differs from the local calendar day (e.g. Monday UTC 04:00 stored as Sunday local 21:00 in PDT), `prev day` is appended to the annotation. Slots are sorted by local start time for readability.

### Phase 4 — Python Tools

- `navien_schedule_learner.py`: removed `local_tz` parameter from `_extract_cold_starts()` and `fetch_consumption_events()`; `dow` and `minute_of_day` now derived from UTC datetimes; removed `detect_local_timezone()` call from `main()`.
- `navien_bootstrap.py`: removed `detect_local_timezone()` call; updated `fetch_consumption_events()` call signature.
- `navien_bucket_export.py`: removed `local_tz` from `build_bucket_payload()` signature; sends `schema_version: 2` with UTC-indexed buckets.

## Post-Flash Steps Required

1. Flash firmware.
2. Verify weblog shows `schedVersion` migration reset message.
3. Apply Phase 4 Python changes (already done on this branch).
4. Run `python3 navien_bucket_export.py --push --replace` to re-seed UTC buckets from InfluxDB.
5. Open Eve app → Programs tab → re-save the week schedule (triggers `convertEveSlotsToUTC()` → NVS write).
6. Verify `telnet scheduler` shows correct local times with UTC annotation.
7. Verify Eve shows correct schedule times.
8. Wait for a scheduled recirc event and confirm it fires at the correct local wall-clock time.

## Files Changed

| File | Change |
|---|---|
| `TimeUtils.h` / `TimeUtils.cpp` | New — `proper_timegm()` implementation |
| `TimeUtils_test.cpp` | New — host-side unit test harness |
| `FakeGatoScheduler.h` / `.cpp` | UTC conversion, offset tracking, sanitize fix |
| `SchedulerBase.cpp` | `gmtime` / `proper_timegm`; remove TZ guard |
| `NavienLearner.h` / `.cpp` | UTC buckets; 24h elapsed recompute timer |
| `BucketStore.h` / `.cpp` | `gmtime`; schema version bump to 2 |
| `NavienManager.ino` | Epoch-check time-init gate |
| `TelnetCommands.cpp` | Local+UTC slot display with `prev day` annotation |
| `Logger/navien_schedule_learner.py` | Remove `local_tz`; UTC-native events |
| `Logger/navien_bootstrap.py` | Remove `local_tz` |
| `Logger/navien_bucket_export.py` | Remove `local_tz`; send `schema_version: 2` |
